### PR TITLE
http2-client: implement some 'no HTTP/2' heuristics

### DIFF
--- a/http2-client/Package.swift
+++ b/http2-client/Package.swift
@@ -10,12 +10,13 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-nio", from: "2.0.0"),
         .package(url: "https://github.com/apple/swift-nio-ssl", from: "2.0.0"),
         .package(url: "https://github.com/apple/swift-nio-http2", from: "1.0.0"),
+        .package(url: "https://github.com/apple/swift-nio-extras", from: "1.0.0"),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
         // Targets can depend on other targets in this package, and on products in packages which this package depends on.
         .target(
             name: "http2-client",
-            dependencies: ["NIO", "NIOSSL", "NIOHTTP1", "NIOHTTP2"]),
+            dependencies: ["NIO", "NIOSSL", "NIOHTTP1", "NIOHTTP2", "NIOTLS", "NIOExtras"]),
     ]
 )

--- a/http2-client/scripts/test_top_sites.sh
+++ b/http2-client/scripts/test_top_sites.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the SwiftNIO open source project
+##
+## Copyright (c) 2019 Apple Inc. and the SwiftNIO project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
+
+set -eu
+
+here="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd "$here/.."
+
+tmp=$(mktemp -d /tmp/.test_top_sites_XXXXXX)
+nio_errors=0
+
+echo -n 'compiling...'
+swift run http2-client https://google.com > "$tmp/compiling" 2>&1 || { cat "$tmp/compiling"; exit 1; }
+echo OK
+
+while read site; do
+    url="https://www.$site"
+    is_http2=true
+    printf "testing %30s: " "$url"
+    if curl --connect-timeout 10 --http2-prior-knowledge -Iv "$url" > "$tmp/curl" 2>&1; then
+        if grep -q HTTP/1 "$tmp/curl"; then
+            echo -n 'curl HTTP/1.x only'
+            is_http2=false
+        else
+            echo -n 'curl HTTP/2 ok    '
+        fi
+    else
+        is_http2=false
+        echo -n 'curl failed       '
+    fi
+
+    if swift run http2-client "$url" > "$tmp/nio"; then
+        echo '; NIO ok'
+    else
+        if grep -q serverDoesNotSpeakHTTP2 "$tmp/nio"; then
+            if $is_http2; then
+                nio_errors=$(( nio_errors + 1 ))
+                echo '; NIO WRONGLY detected no HTTP/2'
+            else
+                echo '; NIO correctly detected no HTTP/2'
+            fi
+        else
+            nio_errors=$(( nio_errors + 1 ))
+            echo '; NIO DID NOT DETECT MISSING HTTP/2'
+            echo "--- NIO DEBUG INFO: BEGIN ---"
+            cat "$tmp/nio"
+            echo "--- NIO DEBUG INFO: END ---"
+        fi
+    fi
+done < <(curl -qs https://moz.com/top500/domains/csv | sed 1d | head -n 100 | cut -d, -f2 | tr -d '"' | \
+    grep -v -e ^qq.com -e ^go.com -e ^who.int)
+
+rm -rf "$tmp"
+exit "$nio_errors"


### PR DESCRIPTION
Motivation:

Sometimes, servers don't speak HTTP/2 and we didn't properly detect
that. There's no great way to detecting that but no we support the three
most common ones:

1. uncleanShutdown before the first byte was sent
2. server just sends a 'HTTP/1.x 400 Bad Request'
3. server immediately initiates (a clean) TLS shutdown

Modification:

- Heuristics for the two failures above
- Added a check script for the top sites, output similar to this:

```
testing      https://www.facebook.com/: curl HTTP/2 ok    ; NIO ok
testing       https://www.twitter.com/: curl HTTP/2 ok    ; NIO ok
testing        https://www.google.com/: curl HTTP/2 ok    ; NIO ok
testing       https://www.youtube.com/: curl HTTP/2 ok    ; NIO ok
testing     https://www.instagram.com/: curl HTTP/2 ok    ; NIO ok
testing      https://www.linkedin.com/: curl HTTP/2 ok    ; NIO ok
testing     https://www.wordpress.org/: curl HTTP/2 ok    ; NIO ok
testing     https://www.pinterest.com/: curl HTTP/2 ok    ; NIO ok
testing     https://www.wikipedia.org/: curl HTTP/2 ok    ; NIO ok
testing     https://www.wordpress.com/: curl HTTP/2 ok    ; NIO ok
testing      https://www.blogspot.com/: curl HTTP/2 ok    ; NIO ok
testing         https://www.apple.com/: curl HTTP/2 ok    ; NIO ok
testing         https://www.adobe.com/: curl HTTP/2 ok    ; NIO ok
testing        https://www.tumblr.com/: curl HTTP/2 ok    ; NIO ok
testing          https://www.youtu.be/: curl failed       ; NIO ok
testing        https://www.amazon.com/: curl HTTP/2 ok    ; NIO ok
testing            https://www.goo.gl/: curl HTTP/2 ok    ; NIO ok
testing         https://www.vimeo.com/: curl HTTP/1.x only; NIO correctly detected no HTTP/2
testing        https://www.flickr.com/: curl HTTP/2 ok    ; NIO ok
testing     https://www.microsoft.com/: curl HTTP/2 ok    ; NIO ok
testing         https://www.yahoo.com/: curl HTTP/2 ok    ; NIO ok
testing       https://www.godaddy.com/: curl HTTP/2 ok    ; NIO ok
testing            https://www.bit.ly/: curl HTTP/1.x only; NIO correctly detected no HTTP/2
testing            https://www.vk.com/: curl HTTP/2 ok    ; NIO ok
testing        https://www.reddit.com/: curl HTTP/2 ok    ; NIO ok
testing            https://www.w3.org/: curl HTTP/2 ok    ; NIO ok
testing         https://www.baidu.com/: curl HTTP/1.x only; NIO correctly detected no HTTP/2
testing       https://www.nytimes.com/: curl HTTP/2 ok    ; NIO ok
testing              https://www.t.co/: curl HTTP/2 ok    ; NIO ok
```

Result:

- Better UX for http2-client
- fixes #13 