### PR TITLE
Avoid using the ELG existential.

### DIFF
--- a/json-rpc/Sources/JsonRpc/Client.swift
+++ b/json-rpc/Sources/JsonRpc/Client.swift
@@ -2,11 +2,11 @@ import Foundation
 import NIO
 
 public final class TCPClient {
-    public let group: EventLoopGroup
+    public let group: MultiThreadedEventLoopGroup
     public let config: Config
     private var channel: Channel?
 
-    public init(group: EventLoopGroup, config: Config = Config()) {
+    public init(group: MultiThreadedEventLoopGroup, config: Config = Config()) {
         self.group = group
         self.config = config
         self.channel = nil

--- a/json-rpc/Sources/JsonRpc/Server.swift
+++ b/json-rpc/Sources/JsonRpc/Server.swift
@@ -2,12 +2,12 @@ import Foundation
 import NIO
 
 public final class TCPServer {
-    private let group: EventLoopGroup
+    private let group: MultiThreadedEventLoopGroup
     private let config: Config
     private var channel: Channel?
     private let closure: RPCClosure
 
-    public init(group: EventLoopGroup, config: Config = Config(), closure: @escaping RPCClosure) {
+    public init(group: MultiThreadedEventLoopGroup, config: Config = Config(), closure: @escaping RPCClosure) {
         self.group = group
         self.config = config
         self.closure = closure


### PR DESCRIPTION
Motivation:

While TCPClient and TCPServer accept the generic EventLoopGroup existential, they don't actually
support any random ELG: they only support MultiThreadedEventLoopGroup and SelectableEventLoop. It's
not currently possible to express a generic constraint that covers that use-case, but having
runtime errors from using NIOTSEventLoopGroup is pretty unpleasant. As all current use-cases use
a MultiThreadedEventLoopGroup, it would be best to do that here as well to avoid the risk of confusion.

Modifications:

- Drop the ELG existential and replace it with MultiThreadedEventLoopGroup.

Result:

Happier users.
