### PR TITLE
fix Swift 5 update warnings

### DIFF
--- a/NIOSMTP/NIOSMTP.xcodeproj/project.pbxproj
+++ b/NIOSMTP/NIOSMTP.xcodeproj/project.pbxproj
@@ -143,7 +143,7 @@
 				TargetAttributes = {
 					8FBA255321270ADB0034D800 = {
 						CreatedOnToolsVersion = 10.0;
-						LastSwiftMigration = 1000;
+						LastSwiftMigration = 1100;
 					};
 				};
 			};
@@ -354,7 +354,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.apple.icloud.jweiss.NIOSMTP;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -375,7 +375,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.apple.icloud.jweiss.NIOSMTP;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;


### PR DESCRIPTION
Motivation:

Warnings aren't great and the project is already a Swift 5 package.

Modification:

Mark the project as Swift 5 project.

Result:

Fewer warnings