### PR TITLE
must send headers before body

### DIFF
--- a/http2-client/Sources/http2-client/main.swift
+++ b/http2-client/Sources/http2-client/main.swift
@@ -46,12 +46,12 @@ final class SendRequestHandler: ChannelInboundHandler {
                                       method: self.compoundRequest.method,
                                       uri: self.compoundRequest.target)
         reqHead.headers = headers
+        context.write(self.wrapOutboundOut(.head(reqHead)), promise: nil)
         if let body = self.compoundRequest.body {
             var buffer = context.channel.allocator.buffer(capacity: body.count)
             buffer.writeBytes(body)
             context.write(self.wrapOutboundOut(.body(.byteBuffer(buffer))), promise: nil)
         }
-        context.write(self.wrapOutboundOut(.head(reqHead)), promise: nil)
         context.writeAndFlush(self.wrapOutboundOut(.end(self.compoundRequest.trailers.map(HTTPHeaders.init))), promise: nil)
     }
     


### PR DESCRIPTION
Request body moved after headers.

### Motivation:

Error:
  request body was before headers

### Modifications:

Request body moved after headers.

### Result:

Try send any request with body, it will completes fine.
