### PR TITLE
http2-client: support multiple requests

### DIFF
--- a/http2-client/Sources/http2-client/Types.swift
+++ b/http2-client/Sources/http2-client/Types.swift
@@ -14,6 +14,11 @@
 
 import NIOHTTP1
 
+struct HostAndPort: Equatable, Hashable {
+    var host: String
+    var port: Int
+}
+
 public struct HTTPRequest {
     class _Storage {
         var method: HTTPMethod


### PR DESCRIPTION
Motivation:

We didn't have a good example on how to support multiple HTTP/2 streams
within one TCP connection.

Modification:

Add the ability to do multiple requests that if they are for the same
host will go over one HTTP/2 connection.

Result:

Better examples.