### PR TITLE
example HTTP/2 server

### DIFF
--- a/http2-server/.gitignore
+++ b/http2-server/.gitignore
@@ -1,0 +1,7 @@
+.DS_Store
+/.build
+/Packages
+/*.xcodeproj
+xcuserdata/
+Package.resolved
+.swiftpm

--- a/http2-server/Package.swift
+++ b/http2-server/Package.swift
@@ -1,0 +1,32 @@
+// swift-tools-version:5.1
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2019 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import PackageDescription
+
+let package = Package(
+    name: "http2-server",
+    dependencies: [
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.5.1"),
+        .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.2.0"),
+        .package(url: "https://github.com/apple/swift-nio-http2.git", from: "1.4.0"),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
+        // Targets can depend on other targets in this package, and on products in packages which this package depends on.
+        .target(
+            name: "http2-server",
+            dependencies: ["NIO", "NIOHTTP1", "NIOHTTP2", "NIOSSL"]),
+    ]
+)

--- a/http2-server/README.md
+++ b/http2-server/README.md
@@ -1,0 +1,9 @@
+# http2-server
+
+This is a very simple example HTTP/2 server that configures TLS (and ALPN)
+similar to how you would configure it in a real system.
+
+To run, just open the project in Xcode or type
+
+    swift run
+

--- a/http2-server/Sources/http2-server/HardcodedPrivateKeyAndCerts.swift
+++ b/http2-server/Sources/http2-server/HardcodedPrivateKeyAndCerts.swift
@@ -1,0 +1,70 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2019 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+// WARNING
+// =======
+//
+// This is an example certificate/private key. DEFINITELY DO NOT USE THESE IN PRODUCTION.
+// The only reason they are here is to make the example server easier to start.
+
+let samplePemCert = """
+-----BEGIN CERTIFICATE-----
+MIIC+zCCAeOgAwIBAgIJANG6W1v704/aMA0GCSqGSIb3DQEBBQUAMBQxEjAQBgNV
+BAMMCWxvY2FsaG9zdDAeFw0xOTA4MDExMDMzMjhaFw0yOTA3MjkxMDMzMjhaMBQx
+EjAQBgNVBAMMCWxvY2FsaG9zdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoC
+ggEBAMLw9InBMGKUNZKXFIpjUYt+Tby42GRQaRFmHfUrlYkvI9L7i9cLqltX/Pta
+XL9zISJIEgIgOW1R3pQ4xRP3xC+C3lKpo5lnD9gaMnDIsXhXLQzvTo+tFgtShXsU
+/xGl4U2Oc2BbPmydd+sfOPKXOYk/0TJsuSb1U5pA8FClyJUrUlykHkN120s5GhfA
+P2KYP+RMZuaW7gNlDEhiInqYUxBpLE+qutAYIDdpKWgxmHKW1oLhZ70TT1Zs7tUI
+22ydjo81vbtB4214EDX0KRRBep+Kq9vTigss34CwhYvyhaCP6l305Z9Vjtu1q1vp
+a3nfMeVtcg6JDn3eogv0CevZMc0CAwEAAaNQME4wHQYDVR0OBBYEFK6KIoQAlLog
+bBT3snTQ22x5gmXQMB8GA1UdIwQYMBaAFK6KIoQAlLogbBT3snTQ22x5gmXQMAwG
+A1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEFBQADggEBAEgoqcGDMriG4cCxWzuiXuV7
+3TthA8TbdHQOeucNvXt9b3HUG1fQo7a0Tv4X3136SfCy3SsXXJr43snzVUK9SuNb
+ntqhAOIudZNw8KSwe+qJwmSEO4y3Lwr5pFfUUkGkV4K86wv3LmBpo3jep5hbkpAc
+kvbzTynFrOILV0TaDkF46KHIoyAb5vPneapdW7rXbX1Jba3jo9PyvHRMeoh/I8zt
+4g+Je2PpH1TJ/GT9dmYhYgJaIssVpv/fWkWphVXwMmpqiH9vEbln8piXHxvCj9XU
+y7uc6N1VUvIvygzUsR+20wjODoGiXp0g0cj+38n3oG5S9rBd1iGEPMAA/2lQS/0=
+-----END CERTIFICATE-----
+"""
+
+let samplePKCS8PemPrivateKey = """
+-----BEGIN RSA PRIVATE KEY-----
+MIIEowIBAAKCAQEAwvD0icEwYpQ1kpcUimNRi35NvLjYZFBpEWYd9SuViS8j0vuL
+1wuqW1f8+1pcv3MhIkgSAiA5bVHelDjFE/fEL4LeUqmjmWcP2BoycMixeFctDO9O
+j60WC1KFexT/EaXhTY5zYFs+bJ136x848pc5iT/RMmy5JvVTmkDwUKXIlStSXKQe
+Q3XbSzkaF8A/Ypg/5Exm5pbuA2UMSGIiephTEGksT6q60BggN2kpaDGYcpbWguFn
+vRNPVmzu1QjbbJ2OjzW9u0HjbXgQNfQpFEF6n4qr29OKCyzfgLCFi/KFoI/qXfTl
+n1WO27WrW+lred8x5W1yDokOfd6iC/QJ69kxzQIDAQABAoIBAQCX+KZ62cuxnh8h
+l3wg4oqIt788l9HCallugfBq2D5sQv6nlQiQbfyx1ydWgDx71/IFuq+nTp3WVpOx
+c4xYI7ii3WAaizsJ9SmJ6+pUuHB6A2QQiGLzaRkdXIjIyjaK+IlrH9lcTeWdYSlC
+eAW6QSBOmhypNc8lyu0Q/P0bshJsDow5iuy3d8PeT3klxgRPWjgjLZj0eUA0Orfp
+s6rC3t7wq8S8+YscKNS6dO0Vp2rF5ZHYYZ9kG5Y0PbAx24hDoYcgMJYJSw5LuR9D
+TkNcstHI8aKM7t9TZN0eXeLmzKXAbkD0uyaK0ZwI2panFDBjkjnkwS7FjHDusk1S
+Or36zCV1AoGBAOj8ALqa5y4HHl2QF8+dkH7eEFnKmExd1YX90eUuO1v7oTW4iQN+
+Z/me45exNDrG27+w8JqF66zH+WAfHv5Va0AUnTuFAyBmOEqit0m2vFzOLBgDGub1
+xOVYQQ5LetIbiXYU4H3IQDSO+UY27u1yYsgYMrO1qiyGgEkFSbK5xh6HAoGBANYy
+3rv9ULu3ZzeLqmkO+uYxBaEzAzubahgcDniKrsKfLVywYlF1bzplgT9OdGRkwMR8
+K7K5s+6ehrIu8pOadP1fZO7GC7w5lYypbrH74E7mBXSP53NOOebKYpojPhxjMrtI
+HLOxGg742WY5MTtDZ81Va0TrhErb4PxccVQEIY4LAoGAc8TMw+y21Ps6jnlMK6D6
+rN/BNiziUogJ0qPWCVBYtJMrftssUe0c0z+tjbHC5zXq+ax9UfsbqWZQtv+f0fc1
+7MiRfILSk+XXMNb7xogjvuW/qUrZskwLQ38ADI9a/04pluA20KmRpcwpd0dSn/BH
+v2+uufeaELfgxOf4v/Npy78CgYBqmqzB8QQCOPg069znJp52fEVqAgKE4wd9clE9
+awApOqGP9PUpx4GRFb2qrTg+Uuqhn478B3Jmux0ch0MRdRjulVCdiZGDn0Ev3Y+L
+I2lyuwZSCeDOQUuN8oH6Zrnd1P0FupEWWXk3pGBGgQZgkV6TEgUuKu0PeLlTwApj
+Hx84GwKBgHWqSoiaBml/KX+GBUDu8Yp0v+7dkNaiU/RVaSEOFl2wHkJ+bq4V+DX1
+lgofMC2QvBrSinEjHrQPZILl+lOq/ppDcnxhY/3bljsutcgHhIT7PKYDOxFqflMi
+ahwyQwRg2oQ2rBrBevgOKFEuIV62WfDYXi8SlT8QaZpTt2r4PYt4
+-----END RSA PRIVATE KEY-----
+"""

--- a/http2-server/Sources/http2-server/main.swift
+++ b/http2-server/Sources/http2-server/main.swift
@@ -1,0 +1,189 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2019 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import NIO
+import NIOSSL
+import NIOHTTP1
+import NIOHTTP2
+
+final class HTTP1TestServer: ChannelInboundHandler {
+    public typealias InboundIn = HTTPServerRequestPart
+    public typealias OutboundOut = HTTPServerResponsePart
+
+    public func channelRead(context: ChannelHandlerContext, data: NIOAny) {
+        guard case .end = self.unwrapInboundIn(data) else {
+            return
+        }
+
+        // Insert an event loop tick here. This more accurately represents real workloads in SwiftNIO, which will not
+        // re-entrantly write their response frames.
+        context.eventLoop.execute {
+            context.channel.getOption(HTTP2StreamChannelOptions.streamID).flatMap { (streamID) -> EventLoopFuture<Void> in
+                var headers = HTTPHeaders()
+                headers.add(name: "content-length", value: "5")
+                headers.add(name: "x-stream-id", value: String(Int(streamID)))
+                context.channel.write(self.wrapOutboundOut(HTTPServerResponsePart.head(HTTPResponseHead(version: .init(major: 2, minor: 0), status: .ok, headers: headers))), promise: nil)
+
+                var buffer = context.channel.allocator.buffer(capacity: 12)
+                buffer.writeStaticString("hello")
+                context.channel.write(self.wrapOutboundOut(HTTPServerResponsePart.body(.byteBuffer(buffer))), promise: nil)
+                return context.channel.writeAndFlush(self.wrapOutboundOut(HTTPServerResponsePart.end(nil)))
+            }.whenComplete { _ in
+                context.close(promise: nil)
+            }
+        }
+    }
+}
+
+
+final class ErrorHandler: ChannelInboundHandler {
+    typealias InboundIn = Never
+
+    func errorCaught(context: ChannelHandlerContext, error: Error) {
+        print("Server received error: \(error)")
+        context.close(promise: nil)
+    }
+}
+
+// First argument is the program path
+let arguments = CommandLine.arguments
+let arg1 = arguments.dropFirst().first
+let arg2 = arguments.dropFirst().dropFirst().first
+let arg3 = arguments.dropFirst().dropFirst().dropFirst().first
+
+let defaultHost = "::1"
+let defaultPort: Int = 8888
+let defaultHtdocs = "/dev/null/"
+
+enum BindTo {
+    case ip(host: String, port: Int)
+    case unixDomainSocket(path: String)
+}
+
+let htdocs: String
+let bindTarget: BindTo
+switch (arg1, arg1.flatMap { Int($0) }, arg2, arg2.flatMap { Int($0) }, arg3) {
+case (.some(let h), _ , _, .some(let p), let maybeHtdocs):
+    /* second arg an integer --> host port [htdocs] */
+    bindTarget = .ip(host: h, port: p)
+    htdocs = maybeHtdocs ?? defaultHtdocs
+case (_, .some(let p), let maybeHtdocs, _, _):
+    /* first arg an integer --> port [htdocs] */
+    bindTarget = .ip(host: defaultHost, port: p)
+    htdocs = maybeHtdocs ?? defaultHtdocs
+case (.some(let portString), .none, let maybeHtdocs, .none, .none):
+    /* couldn't parse as number --> uds-path [htdocs] */
+    bindTarget = .unixDomainSocket(path: portString)
+    htdocs = maybeHtdocs ?? defaultHtdocs
+default:
+    htdocs = defaultHtdocs
+    bindTarget = BindTo.ip(host: defaultHost, port: defaultPort)
+}
+
+// The following lines load the example private key/cert from HardcodedPrivateKeyAndCerts.swift .
+// DO NOT USE THESE KEYS/CERTIFICATES IN PRODUCTION.
+// For a real server, you would obtain a real key/cert and probably put them in files and load them with
+//
+//     NIOSSLPrivateKeySource.file("/path/to/private.key")
+//     NIOSSLCertificateSource.file("/path/to/my.cert")
+
+// Load the private key
+let sslPrivateKey = try! NIOSSLPrivateKeySource.privateKey(NIOSSLPrivateKey(buffer: [Int8](samplePKCS8PemPrivateKey.utf8CString),
+                                                                           format: .pem) { providePassword in
+                                                                            providePassword("thisisagreatpassword".utf8)
+})
+
+// Load the certificate
+let sslCertificate = try! NIOSSLCertificateSource.certificate(NIOSSLCertificate(buffer: [Int8](samplePemCert.utf8CString),
+                                                                               format: .pem))
+
+// Set up the TLS configuration, it's important to set the `applicationProtocols` to
+// `NIOHTTP2SupportedALPNProtocols` which (using ALPN (https://en.wikipedia.org/wiki/Application-Layer_Protocol_Negotiation))
+// advertises the support of HTTP/2 to the client.
+let tlsConfiguration = TLSConfiguration.forServer(certificateChain: [sslCertificate],
+                                                  privateKey: sslPrivateKey,
+                                                  applicationProtocols: NIOHTTP2SupportedALPNProtocols)
+// Configure the SSL context that is used by all SSL handlers.
+let sslContext = try! NIOSSLContext(configuration: tlsConfiguration)
+
+let group = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
+let bootstrap = ServerBootstrap(group: group)
+    // Specify backlog and enable SO_REUSEADDR for the server itself
+    .serverChannelOption(ChannelOptions.backlog, value: 256)
+    .serverChannelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR), value: 1)
+
+    // Set the handlers that are applied to the accepted Channels
+    .childChannelInitializer { channel in
+        // First, we need an SSL handler because HTTP/2 is almost always spoken over TLS.
+        channel.pipeline.addHandler(try! NIOSSLServerHandler(context: sslContext)).flatMap {
+            // Right after the SSL handler, we can configure the HTTP/2 pipeline.
+            channel.configureHTTP2Pipeline(mode: .server) { (streamChannel, streamID) -> EventLoopFuture<Void> in
+                // For every HTTP/2 stream that the client opens, we put in the `HTTP2ToHTTP1ServerCodec` which
+                // transforms the HTTP/2 frames to the HTTP/1 messages from the `NIOHTTP1` module.
+                streamChannel.pipeline.addHandler(HTTP2ToHTTP1ServerCodec(streamID: streamID)).flatMap { () -> EventLoopFuture<Void> in
+                    // And lastly, we put in our very basic HTTP server :).
+                    streamChannel.pipeline.addHandler(HTTP1TestServer())
+                }.flatMap { () -> EventLoopFuture<Void> in
+                    streamChannel.pipeline.addHandler(ErrorHandler())
+                }
+            }
+        }.flatMap { (_: HTTP2StreamMultiplexer) in
+            return channel.pipeline.addHandler(ErrorHandler())
+        }
+    }
+
+    // Enable TCP_NODELAY and SO_REUSEADDR for the accepted Channels
+    .childChannelOption(ChannelOptions.socket(IPPROTO_TCP, TCP_NODELAY), value: 1)
+    .childChannelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR), value: 1)
+    .childChannelOption(ChannelOptions.maxMessagesPerRead, value: 1)
+
+defer {
+    try! group.syncShutdownGracefully()
+}
+
+print("htdocs = \(htdocs)")
+
+let channel = try { () -> Channel in
+    switch bindTarget {
+    case .ip(let host, let port):
+        return try bootstrap.bind(host: host, port: port).wait()
+    case .unixDomainSocket(let path):
+        return try bootstrap.bind(unixDomainSocketPath: path).wait()
+    }
+    }()
+
+print("Server started and listening on \(channel.localAddress!), htdocs path \(htdocs)")
+print("\nTry it out by running")
+print("    # WARNING: We're passing --insecure here because we don't have a real cert/private key!")
+print("    # In production NEVER use --insecure.")
+switch bindTarget {
+case .ip(let host, let port):
+    let hostFormatted: String
+    switch channel.localAddress!.protocolFamily {
+    case AF_INET6:
+        hostFormatted = host.contains(":") ? "[\(host)]" : host
+    default:
+        hostFormatted = "\(host)"
+    }
+    print("    curl --insecure https://\(hostFormatted):\(port)/hello-world")
+case .unixDomainSocket(let path):
+    print("    curl --insecure --unix-socket '\(path)' https://ignore-the-server.name/hello-world")
+}
+
+
+// This will never unblock as we don't close the ServerChannel
+try channel.closeFuture.wait()
+
+print("Server closed")
+


### PR DESCRIPTION
Motivation:

We need better and more real-world examples because configuring HTTP/2
isn't that easy because it always requires TLS and ALPN to be set up
appropriately.

Motifications:

Set up the most simple HTTP/2 server over TLS.

Result:

More examples.