### PR TITLE
use secure http2 versions

### DIFF
--- a/http2-client/Package.swift
+++ b/http2-client/Package.swift
@@ -9,7 +9,7 @@ let package = Package(
         // Dependencies declare other packages that this package depends on.
         .package(url: "https://github.com/apple/swift-nio", from: "2.0.0"),
         .package(url: "https://github.com/apple/swift-nio-ssl", from: "2.0.0"),
-        .package(url: "https://github.com/apple/swift-nio-http2", from: "1.0.0"),
+        .package(url: "https://github.com/apple/swift-nio-http2", from: "1.5.0"),
         .package(url: "https://github.com/apple/swift-nio-extras", from: "1.0.0"),
     ],
     targets: [

--- a/http2-server/Package.swift
+++ b/http2-server/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.5.1"),
         .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.2.0"),
-        .package(url: "https://github.com/apple/swift-nio-http2.git", from: "1.4.0"),
+        .package(url: "https://github.com/apple/swift-nio-http2.git", from: "1.5.0"),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.


### PR DESCRIPTION
Motivation:

Our examples should use secure versions.

Modification:

Use swift-nio-http2 from 1.5.0.

Result:

More secure examples.