### PR TITLE
NIOSMTP: Implement StartTLS

### DIFF
--- a/NIOSMTP/NIOSMTP/Configuration.swift
+++ b/NIOSMTP/NIOSMTP/Configuration.swift
@@ -20,17 +20,12 @@ struct Configuration {
         // If you don't want to use your real SMTP server, do try out https://mailtrap.io they offer you an
         // SMTP server that can be used for testing for free.
         let serverConfig = ServerConfiguration(hostname: "you.need.to.configure.your.providers.smtp.server",
-                                               port: 465,
+                                               port: 25,
                                                username: "put your username here",
-                                               password: "and your password goes here")
-
-        // In case you don't want to use TLS which is a bad idea and _WILL SEND YOUR PASSWORD IN PLAIN TEXT_
-        // just disable this.
-        let useTLS = true
-
-        return Configuration(serverConfig: serverConfig, useTLS: useTLS)
+                                               password: "and your password goes here",
+                                               tlsConfiguration: .startTLS)
+        return Configuration(serverConfig: serverConfig)
     }()
 
     var serverConfig: ServerConfiguration
-    var useTLS: Bool
 }

--- a/NIOSMTP/NIOSMTP/DataModel.swift
+++ b/NIOSMTP/NIOSMTP/DataModel.swift
@@ -14,6 +14,7 @@
 
 enum SMTPRequest {
     case sayHello(serverName: String)
+    case startTLS
     case beginAuthentication
     case authUser(String)
     case authPassword(String)
@@ -30,10 +31,21 @@ enum SMTPResponse {
 }
 
 struct ServerConfiguration {
+    enum TLSConfiguration {
+        /// Use StartTLS, this should be the default and is secure.
+        case startTLS
+
+        /// Directly open a TLS connection. This secure however not widely supported.
+        case regularTLS
+
+        /// This should never be used. It will literally _SEND YOUR PASSWORD IN PLAINTEXT OVER THE INTERNET_.
+        case unsafeNoTLS
+    }
     var hostname: String
     var port: Int
     var username: String
     var password: String
+    var tlsConfiguration: TLSConfiguration
 }
 
 struct Email {

--- a/NIOSMTP/NIOSMTP/SMTPRequestEncoder.swift
+++ b/NIOSMTP/NIOSMTP/SMTPRequestEncoder.swift
@@ -22,7 +22,9 @@ final class SMTPRequestEncoder: MessageToByteEncoder {
     func encode(data: SMTPRequest, out: inout ByteBuffer) throws {
         switch data {
         case .sayHello(serverName: let server):
-            out.writeString("HELO \(server)")
+            out.writeString("EHLO \(server)")
+        case .startTLS:
+            out.writeString("STARTTLS")
         case .mailFrom(let from):
             out.writeString("MAIL FROM:<\(from)>")
         case .recipient(let rcpt):

--- a/NIOSMTP/NIOSMTP/SendEmailHandler.swift
+++ b/NIOSMTP/NIOSMTP/SendEmailHandler.swift
@@ -13,7 +13,10 @@
 //===----------------------------------------------------------------------===//
 
 import NIO
+import NIOSSL
 import UIKit
+
+private let sslContext = try! NIOSSLContext(configuration: TLSConfiguration.forClient())
 
 final class SendEmailHandler: ChannelInboundHandler {
     typealias InboundIn = SMTPResponse
@@ -23,6 +26,8 @@ final class SendEmailHandler: ChannelInboundHandler {
     enum Expect {
         case initialMessageFromServer
         case okForOurHello
+        case okForStartTLS
+        case tlsHandlerToBeAdded
         case okForOurAuthBegin
         case okAfterUsername
         case okAfterPassword
@@ -33,13 +38,26 @@ final class SendEmailHandler: ChannelInboundHandler {
         case okAfterQuit
         case nothing
         
-        case error
+        case error(Error)
     }
     
-    private var currentlyWaitingFor = Expect.initialMessageFromServer
+    private var currentlyWaitingFor = Expect.initialMessageFromServer {
+        didSet {
+            if case .error(let error) = self.currentlyWaitingFor {
+                self.allDonePromise.fail(error)
+            }
+        }
+    }
     private let email: Email
     private let serverConfiguration: ServerConfiguration
     private let allDonePromise: EventLoopPromise<Void>
+    private var useStartTLS: Bool {
+        if case .startTLS = self.serverConfiguration.tlsConfiguration {
+            return true
+        } else {
+            return false
+        }
+    }
     
     init(configuration: ServerConfiguration, email: Email, allDonePromise: EventLoopPromise<Void>) {
         self.email = email
@@ -49,6 +67,45 @@ final class SendEmailHandler: ChannelInboundHandler {
     
     func send(context: ChannelHandlerContext, command: SMTPRequest) {
         context.writeAndFlush(self.wrapOutboundOut(command)).cascadeFailure(to: self.allDonePromise)
+    }
+
+    func sendAuthenticationStart(context: ChannelHandlerContext) {
+        func goAhead() {
+            self.send(context: context, command: .beginAuthentication)
+            self.currentlyWaitingFor = .okForOurAuthBegin
+        }
+
+        switch self.serverConfiguration.tlsConfiguration {
+        case .regularTLS, .startTLS:
+            // Let's make sure we actually have a TLS handler. This code is here purely to make sure we don't have a
+            // bug in the code base that would lead to sending any sensitive data without TLS (unless the user asked
+            // us to do so.)
+            context.channel.pipeline.handler(type: NIOSSLClientHandler.self).map { (_: NIOSSLClientHandler) in
+                // we don't actually care about the NIOSSLClientHandler but we must be sure it's there.
+                goAhead()
+            }.whenFailure { error in
+                if NetworkImplementation.best == .transportServices && self.serverConfiguration.tlsConfiguration == .regularTLS {
+                    // If we're using NIOTransportServices and regular TLS, then TLS must have been configured ahead
+                    // of time, we can't check it here.
+                } else {
+                    preconditionFailure("serious NIOSMTP bug: TLS handler should be present in " +
+                        "\(self.serverConfiguration.tlsConfiguration) but SSL handler \(error)")
+                }
+            }
+        case .unsafeNoTLS:
+            // sad times here, plaintext
+            goAhead()
+        }
+    }
+
+    func channelInactive(context: ChannelHandlerContext) {
+        self.allDonePromise.fail(ChannelError.eof)
+    }
+
+    func errorCaught(context: ChannelHandlerContext, error: Error) {
+        self.currentlyWaitingFor = .error(error)
+        self.allDonePromise.fail(error)
+        context.close(promise: nil)
     }
     
     func channelRead(context: ChannelHandlerContext, data: NIOAny) {
@@ -66,8 +123,28 @@ final class SendEmailHandler: ChannelInboundHandler {
             self.send(context: context, command: .sayHello(serverName: self.serverConfiguration.hostname))
             self.currentlyWaitingFor = .okForOurHello
         case .okForOurHello:
-            self.send(context: context, command: .beginAuthentication)
-            self.currentlyWaitingFor = .okForOurAuthBegin
+            if self.useStartTLS {
+                self.send(context: context, command: .startTLS)
+                self.currentlyWaitingFor = .okForStartTLS
+            } else {
+                self.sendAuthenticationStart(context: context)
+            }
+        case .okForStartTLS:
+            self.currentlyWaitingFor = .tlsHandlerToBeAdded
+            context.channel.pipeline.addHandler(try! NIOSSLClientHandler(context: sslContext,
+                                                                         serverHostname: serverConfiguration.hostname),
+                                                position: .first).whenComplete { result in
+                guard case .tlsHandlerToBeAdded = self.currentlyWaitingFor else {
+                    preconditionFailure("wrong state \(self.currentlyWaitingFor)")
+                }
+
+                switch result {
+                case .failure(let error):
+                    self.currentlyWaitingFor = .error(error)
+                case .success:
+                    self.sendAuthenticationStart(context: context)
+                }
+            }
         case .okForOurAuthBegin:
             self.send(context: context, command: .authUser(self.serverConfiguration.username))
             self.currentlyWaitingFor = .okAfterUsername
@@ -90,12 +167,15 @@ final class SendEmailHandler: ChannelInboundHandler {
             self.send(context: context, command: .quit)
             self.currentlyWaitingFor = .okAfterQuit
         case .okAfterQuit:
-            context.close(promise: self.allDonePromise)
+            self.allDonePromise.succeed(())
+            context.close(promise: nil)
             self.currentlyWaitingFor = .nothing
         case .nothing:
             () // ignoring more data whilst quit (it's odd though)
         case .error:
             fatalError("error state")
+        case .tlsHandlerToBeAdded:
+            fatalError("bug in NIOTS: we shouldn't hit this state here")
         }
     }
 }


### PR DESCRIPTION
Motivation:

SMTP in 2019 uses STARTTLS, therefore NIOSMTP should support that too.
I have also been asked multiple times if NIOSMTP supported STARTTLS.

Modification:

Support STARTTLS

Result:

- Better examples
- fixes #20 
