### PR TITLE
Add ConnectProxy example.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.build/
+.swiftpm/
+Package.resolved

--- a/connect-proxy/Package.swift
+++ b/connect-proxy/Package.swift
@@ -1,0 +1,30 @@
+// swift-tools-version:5.0
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2019 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import PackageDescription
+
+let package = Package(
+    name: "nio-connect-proxy",
+    products: [
+        .executable(name: "ConnectProxy", targets: ["ConnectProxy"]),
+    ],
+    dependencies: [
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.0.0"),
+        .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
+    ],
+    targets: [
+        .target(name: "ConnectProxy", dependencies: ["NIO", "NIOHTTP1", "Logging"]),
+    ]
+)

--- a/connect-proxy/Sources/ConnectProxy/ConnectHandler.swift
+++ b/connect-proxy/Sources/ConnectProxy/ConnectHandler.swift
@@ -1,0 +1,236 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2019 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import NIO
+import NIOHTTP1
+import Logging
+
+
+final class ConnectHandler {
+    private var upgradeState: State
+
+    private var logger: Logger
+
+    init(logger: Logger) {
+        self.upgradeState = .idle
+        self.logger = logger
+    }
+}
+
+
+extension ConnectHandler {
+    fileprivate enum State {
+        case idle
+        case beganConnecting
+        case awaitingEnd(connectResult: Channel)
+        case awaitingConnection(pendingBytes: [NIOAny])
+        case upgradeComplete(pendingBytes: [NIOAny])
+        case upgradeFailed
+    }
+}
+
+
+extension ConnectHandler: ChannelInboundHandler {
+    typealias InboundIn = HTTPServerRequestPart
+    typealias OutboundOut = HTTPServerResponsePart
+
+    func channelRead(context: ChannelHandlerContext, data: NIOAny) {
+        switch self.upgradeState {
+        case .idle:
+            self.handleInitialMessage(context: context, data: self.unwrapInboundIn(data))
+
+        case .beganConnecting:
+            // We got .end, we're still waiting on the connection
+            if case .end = self.unwrapInboundIn(data) {
+                self.upgradeState = .awaitingConnection(pendingBytes: [])
+                self.removeDecoder(context: context)
+            }
+
+        case .awaitingEnd(let peerChannel):
+            if case .end = self.unwrapInboundIn(data) {
+                // Upgrade has completed!
+                self.upgradeState = .upgradeComplete(pendingBytes: [])
+                self.removeDecoder(context: context)
+                self.glue(peerChannel, context: context)
+            }
+
+        case .awaitingConnection(var pendingBytes):
+            // We've seen end, this must not be HTTP anymore. Danger, Will Robinson! Do not unwrap.
+            self.upgradeState = .awaitingConnection(pendingBytes: [])
+            pendingBytes.append(data)
+            self.upgradeState = .awaitingConnection(pendingBytes: pendingBytes)
+
+        case .upgradeComplete(pendingBytes: var pendingBytes):
+            // We're currently delivering data, keep doing so.
+            self.upgradeState = .upgradeComplete(pendingBytes: [])
+            pendingBytes.append(data)
+            self.upgradeState = .upgradeComplete(pendingBytes: pendingBytes)
+
+        case .upgradeFailed:
+            break
+        }
+    }
+
+    func handlerAdded(context: ChannelHandlerContext) {
+        // Add logger metadata.
+        self.logger[metadataKey: "localAddress"] = "\(String(describing: context.channel.localAddress))"
+        self.logger[metadataKey: "remoteAddress"] = "\(String(describing: context.channel.remoteAddress))"
+        self.logger[metadataKey: "channel"] = "\(ObjectIdentifier(context.channel))"
+    }
+}
+
+
+extension ConnectHandler: RemovableChannelHandler {
+    func removeHandler(context: ChannelHandlerContext, removalToken: ChannelHandlerContext.RemovalToken) {
+        var didRead = false
+
+        // We are being removed, and need to deliver any pending bytes we may have if we're upgrading.
+        while case .upgradeComplete(var pendingBytes) = self.upgradeState, pendingBytes.count > 0 {
+            // Avoid a CoW while we pull some data out.
+            self.upgradeState = .upgradeComplete(pendingBytes: [])
+            let nextRead = pendingBytes.removeFirst()
+            self.upgradeState = .upgradeComplete(pendingBytes: pendingBytes)
+
+            context.fireChannelRead(nextRead)
+            didRead = true
+        }
+
+        if didRead {
+            context.fireChannelReadComplete()
+        }
+
+        self.logger.debug("Removing \(self) from pipeline")
+        context.leavePipeline(removalToken: removalToken)
+    }
+}
+
+extension ConnectHandler {
+    private func handleInitialMessage(context: ChannelHandlerContext, data: InboundIn) {
+        guard case .head(let head) = data else {
+            self.logger.error("Invalid HTTP message type \(data)")
+            self.httpErrorAndClose(context: context)
+            return
+        }
+
+        self.logger.info("\(head.method) \(head.uri) \(head.version)")
+
+        guard head.method == .CONNECT else {
+            self.logger.error("Invalid HTTP method: \(head.method)")
+            self.httpErrorAndClose(context: context)
+            return
+        }
+
+        let components = head.uri.split(separator: ":", maxSplits: 1, omittingEmptySubsequences: false)
+        let host = components.first!  // There will always be a first.
+        let port = components.last.flatMap { Int($0, radix: 10) } ?? 80  // Port 80 if not specified
+
+        self.upgradeState = .beganConnecting
+        self.connectTo(host: String(host), port: port, context: context)
+    }
+
+    private func connectTo(host: String, port: Int, context: ChannelHandlerContext) {
+        self.logger.info("Connecting to \(host):\(port)")
+
+        let channelFuture = ClientBootstrap(group: context.eventLoop)
+            .connect(host: String(host), port: port)
+
+        channelFuture.whenSuccess { channel in
+            self.connectSucceeded(channel: channel, context: context)
+        }
+        channelFuture.whenFailure { error in
+            self.connectFailed(error: error, context: context)
+        }
+    }
+
+    private func connectSucceeded(channel: Channel, context: ChannelHandlerContext) {
+        self.logger.info("Connected to \(String(describing: channel.remoteAddress))")
+
+        switch self.upgradeState {
+        case .beganConnecting:
+            // Ok, we have a channel, let's wait for end.
+            self.upgradeState = .awaitingEnd(connectResult: channel)
+
+        case .awaitingConnection(pendingBytes: let pendingBytes):
+            // Upgrade complete! Begin gluing the connection together.
+            self.upgradeState = .upgradeComplete(pendingBytes: pendingBytes)
+            self.glue(channel, context: context)
+
+        case .idle, .awaitingEnd, .upgradeFailed, .upgradeComplete:
+            // These cases are logic errors, but let's be careful and just shut the connection.
+            context.close(promise: nil)
+        }
+    }
+
+    private func connectFailed(error: Error, context: ChannelHandlerContext) {
+        self.logger.error("Connect failed: \(error)")
+
+        switch self.upgradeState {
+        case .beganConnecting, .awaitingConnection:
+            // We still have a somewhat active connection here in HTTP mode, and can report failure.
+            self.httpErrorAndClose(context: context)
+
+        case .idle, .awaitingEnd, .upgradeFailed, .upgradeComplete:
+            // Most of these cases are logic errors, but let's be careful and just shut the connection.
+            context.close(promise: nil)
+        }
+
+        context.fireErrorCaught(error)
+    }
+
+    private func glue(_ peerChannel: Channel, context: ChannelHandlerContext) {
+        self.logger.debug("Gluing together \(ObjectIdentifier(context.channel)) and \(ObjectIdentifier(peerChannel))")
+
+        // Ok, upgrade has completed! We now need to begin the upgrade process.
+        // First, send the 200 message.
+        // This content-length header is MUST NOT, but we need to workaround NIO's insistence that we set one.
+        let headers = HTTPHeaders([("Content-Length", "0")])
+        let head = HTTPResponseHead(version: .init(major: 1, minor: 1), status: .ok, headers: headers)
+        context.write(self.wrapOutboundOut(.head(head)), promise: nil)
+        context.writeAndFlush(self.wrapOutboundOut(.end(nil)), promise: nil)
+
+        // Now remove the HTTP encoder.
+        self.removeEncoder(context: context)
+
+        // Now we need to glue our channel and the peer channel together.
+        let (localGlue, peerGlue) = GlueHandler.matchedPair()
+        context.channel.pipeline.addHandler(localGlue).and(peerChannel.pipeline.addHandler(peerGlue)).whenComplete { result in
+            _ = context.pipeline.removeHandler(self)
+        }
+    }
+
+    private func httpErrorAndClose(context: ChannelHandlerContext) {
+        self.upgradeState = .upgradeFailed
+
+        let headers = HTTPHeaders([("Content-Length", "0"), ("Connection", "close")])
+        let head = HTTPResponseHead(version: .init(major: 1, minor: 1), status: .badRequest, headers: headers)
+        context.write(self.wrapOutboundOut(.head(head)), promise: nil)
+        context.write(self.wrapOutboundOut(.end(nil))).whenComplete { (_: Result<Void, Error>) in
+            context.close(mode: .output, promise: nil)
+        }
+    }
+
+    private func removeDecoder(context: ChannelHandlerContext) {
+        // We drop the future on the floor here as these handlers must all be in our own pipeline, and this should
+        // therefore succeed fast.
+        _ = context.pipeline.context(handlerType: ByteToMessageHandler<HTTPRequestDecoder>.self).map {
+            context.pipeline.removeHandler(context: $0, promise: nil)
+        }
+    }
+
+    private func removeEncoder(context: ChannelHandlerContext) {
+        _ = context.pipeline.context(handlerType: HTTPResponseEncoder.self).map {
+            context.pipeline.removeHandler(context: $0, promise: nil)
+        }
+    }
+}

--- a/connect-proxy/Sources/ConnectProxy/ConnectProxyError.swift
+++ b/connect-proxy/Sources/ConnectProxy/ConnectProxyError.swift
@@ -1,0 +1,17 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2019 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+enum ConnectProxyError: Error {
+    case invalidHTTPMessageOrdering
+}

--- a/connect-proxy/Sources/ConnectProxy/GlueHandler.swift
+++ b/connect-proxy/Sources/ConnectProxy/GlueHandler.swift
@@ -1,0 +1,122 @@
+///===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2019 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import NIO
+
+
+final class GlueHandler {
+    private var partner: GlueHandler?
+
+    private var context: ChannelHandlerContext?
+
+    private var pendingRead: Bool = false
+
+    private init() { }
+}
+
+
+extension GlueHandler {
+    static func matchedPair() -> (GlueHandler, GlueHandler) {
+        let first = GlueHandler()
+        let second = GlueHandler()
+
+        first.partner = second
+        second.partner = first
+
+        return (first, second)
+    }
+}
+
+
+extension GlueHandler {
+    private func partnerWrite(_ data: NIOAny) {
+        self.context?.write(data, promise: nil)
+    }
+
+    private func partnerFlush() {
+        self.context?.flush()
+    }
+
+    private func partnerWriteEOF() {
+        self.context?.close(mode: .output, promise: nil)
+    }
+
+    private func partnerCloseFull() {
+        self.context?.close(promise: nil)
+    }
+
+    private func partnerBecameWritable() {
+        if self.pendingRead {
+            self.pendingRead = false
+            self.context?.read()
+        }
+    }
+
+    private var partnerWritable: Bool {
+        return self.context?.channel.isWritable ?? false
+    }
+}
+
+
+extension GlueHandler: ChannelDuplexHandler {
+    typealias InboundIn = NIOAny
+    typealias OutboundIn = NIOAny
+    typealias OutboundOut = NIOAny
+
+    func handlerAdded(context: ChannelHandlerContext) {
+        self.context = context
+    }
+
+    func handlerRemoved(context: ChannelHandlerContext) {
+        self.context = nil
+        self.partner = nil
+    }
+
+    func channelRead(context: ChannelHandlerContext, data: NIOAny) {
+        self.partner?.partnerWrite(data)
+    }
+
+    func channelReadComplete(context: ChannelHandlerContext) {
+        self.partner?.partnerFlush()
+    }
+
+    func channelInactive(context: ChannelHandlerContext) {
+        self.partner?.partnerCloseFull()
+    }
+
+    func userInboundEventTriggered(context: ChannelHandlerContext, event: Any) {
+        if let event = event as? ChannelEvent, case .inputClosed = event {
+            // We have read EOF.
+            self.partner?.partnerWriteEOF()
+        }
+    }
+
+    func errorCaught(context: ChannelHandlerContext, error: Error) {
+        self.partner?.partnerCloseFull()
+    }
+
+    func channelWritabilityChanged(context: ChannelHandlerContext) {
+        if context.channel.isWritable {
+            self.partner?.partnerBecameWritable()
+        }
+    }
+
+    func read(context: ChannelHandlerContext) {
+        if let partner = self.partner, partner.partnerWritable {
+            context.read()
+        } else {
+            self.pendingRead = true
+        }
+    }
+}

--- a/connect-proxy/Sources/ConnectProxy/main.swift
+++ b/connect-proxy/Sources/ConnectProxy/main.swift
@@ -1,0 +1,57 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2019 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import NIO
+import NIOHTTP1
+import Logging
+import Dispatch
+
+let group = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
+let bootstrap = ServerBootstrap(group: group)
+    .serverChannelOption(ChannelOptions.socket(SOL_SOCKET, SO_REUSEADDR), value: 1)
+    .childChannelOption(ChannelOptions.socket(SOL_SOCKET, SO_REUSEADDR), value: 1)
+    .childChannelInitializer { channel in
+        channel.pipeline.addHandler(ByteToMessageHandler(HTTPRequestDecoder(leftOverBytesStrategy: .forwardBytes))).flatMap {
+            channel.pipeline.addHandler(HTTPResponseEncoder()).flatMap {
+                channel.pipeline.addHandler(ConnectHandler(logger: Logger(label: "com.apple.nio-connect-proxy.ConnectHandler")))
+            }
+        }
+    }
+
+bootstrap.bind(to: try! SocketAddress(ipAddress: "127.0.0.1", port: 8080)).whenComplete { result in
+    // Need to create this here for thread-safety purposes
+    let logger = Logger(label: "com.apple.nio-connect-proxy.main")
+
+    switch result {
+    case .success(let channel):
+        logger.info("Listening on \(String(describing: channel.localAddress))")
+    case .failure(let error):
+        logger.error("Failed to bind 127.0.0.1:8080, \(error)")
+    }
+}
+
+bootstrap.bind(to: try! SocketAddress(ipAddress: "::1", port: 8080)).whenComplete { result in
+    // Need to create this here for thread-safety purposes
+    let logger = Logger(label: "com.apple.nio-connect-proxy.main")
+
+    switch result {
+    case .success(let channel):
+        logger.info("Listening on \(String(describing: channel.localAddress))")
+    case .failure(let error):
+        logger.error("Failed to bind [::1]:8080, \(error)")
+    }
+}
+
+// Run forever
+dispatchMain()


### PR DESCRIPTION
This is a simple example of a HTTPS CONNECT proxy. It accepts inbound CONNECT requests, establishes the outbound connection, and then glues the two channels together. It's a decent example of how to implement complex pipeline rearrangement, to glue channels together, and to propagate backpressure through multiple layers.

It also performs pretty well, too, with a single core of my Mac capable of getting more than 1Gbps of throughput.