### PR TITLE
Update http2 example using deprecated SSL constructors

### DIFF
--- a/http2-server/Sources/http2-server/main.swift
+++ b/http2-server/Sources/http2-server/main.swift
@@ -99,13 +99,13 @@ default:
 //     NIOSSLCertificateSource.file("/path/to/my.cert")
 
 // Load the private key
-let sslPrivateKey = try! NIOSSLPrivateKeySource.privateKey(NIOSSLPrivateKey(buffer: [Int8](samplePKCS8PemPrivateKey.utf8CString),
+let sslPrivateKey = try! NIOSSLPrivateKeySource.privateKey(NIOSSLPrivateKey(bytes: Array(samplePKCS8PemPrivateKey.utf8),
                                                                            format: .pem) { providePassword in
                                                                             providePassword("thisisagreatpassword".utf8)
 })
 
 // Load the certificate
-let sslCertificate = try! NIOSSLCertificateSource.certificate(NIOSSLCertificate(buffer: [Int8](samplePemCert.utf8CString),
+let sslCertificate = try! NIOSSLCertificateSource.certificate(NIOSSLCertificate(bytes: Array(samplePemCert.utf8),
                                                                                format: .pem))
 
 // Set up the TLS configuration, it's important to set the `applicationProtocols` to


### PR DESCRIPTION
Motivation:

The http2-server example has some compiler warnings regarding
deprecation.

Modifications:

Update the example to use the suggested "bytes" based constructors for
NIOSSLPrivateKey and NIOSSLCertificate.

Result:

No more compiler warnings for the http2-server example.

I also validated it by checking if the example still runs.