### PR TITLE
http2-*: update dependencies

### DIFF
--- a/http2-client/Package.swift
+++ b/http2-client/Package.swift
@@ -7,9 +7,9 @@ let package = Package(
     name: "http2-client",
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(url: "https://github.com/apple/swift-nio", from: "2.0.0"),
-        .package(url: "https://github.com/apple/swift-nio-ssl", from: "2.0.0"),
-        .package(url: "https://github.com/apple/swift-nio-http2", from: "1.5.0"),
+        .package(url: "https://github.com/apple/swift-nio", from: "2.13.0"),
+        .package(url: "https://github.com/apple/swift-nio-ssl", from: "2.6.0"),
+        .package(url: "https://github.com/apple/swift-nio-http2", from: "1.9.0"),
         .package(url: "https://github.com/apple/swift-nio-extras", from: "1.0.0"),
     ],
     targets: [

--- a/http2-server/Package.swift
+++ b/http2-server/Package.swift
@@ -18,9 +18,9 @@ import PackageDescription
 let package = Package(
     name: "http2-server",
     dependencies: [
-        .package(url: "https://github.com/apple/swift-nio.git", from: "2.5.1"),
-        .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.2.0"),
-        .package(url: "https://github.com/apple/swift-nio-http2.git", from: "1.5.0"),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.13.0"),
+        .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.6.0"),
+        .package(url: "https://github.com/apple/swift-nio-http2.git", from: "1.9.0"),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.


### PR DESCRIPTION
### Motivation:

In #45 we updated to the new non-deprecated methods, so we should update the dependencies.
Also, we fixed a bunch of bugs affecting HTTP/2.

### Modifications:

Bump NIO, NIO SSL, and NIO HTTP/2 dependency requirements.

### Result:

Shiny new stuff :).