### PR TITLE
backpressure / file io example

### DIFF
--- a/backpressure-file-io-channel/Package.swift
+++ b/backpressure-file-io-channel/Package.swift
@@ -1,0 +1,15 @@
+// swift-tools-version:5.1
+import PackageDescription
+
+let package = Package(
+    name: "backpressure-file-io-channel",
+    dependencies: [
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.16.1"),
+        .package(url: "https://github.com/apple/swift-log.git", from: "1.1.0"),
+    ],
+    targets: [
+        .target(
+            name: "BackpressureChannelToFileIO",
+            dependencies: ["NIO", "NIOHTTP1", "Logging"]),
+    ]
+)

--- a/backpressure-file-io-channel/README.md
+++ b/backpressure-file-io-channel/README.md
@@ -1,0 +1,90 @@
+# backpressure-file-io-channel
+
+This example shows how you can propagate backpressure from the file system into the Channel.
+
+First, let's establish what it means to propagate backpressure from the file system into the Channel: Let's assume we have a HTTP server
+that accepts arbitrary amounts of data and writes it to the file system. If data is received faster over the network than we can write it to the
+disk, then the server runs into trouble: It can now only either buffer the data in memory or (at least in theory) drop it on the floor. The former
+would easily be usable as a denial of service exploit, the latter means that the server isn't able to provide its core functioniality.
+
+Backpressure is the mechanism to the the buffering issue above. The idea is that the server stops accepting more data from the client than
+it can write to disk. Because HTTP runs over TCP which has flow-control built in, the TCP stacks will then lower the server's receive window
+size which means that the client gets slowed down of completely stopped from sending any data. Once the server finishes writing previously
+received data to disk, it starts draining the receive buffer which then make TCP's flow control raise the window sizes which allows the client
+to send further data.
+
+## Backpressure in SwiftNIO
+
+In SwiftNIO, backpressure is propagated by stopping to call the outbound [`read`](https://apple.github.io/swift-nio/docs/current/NIO/Protocols/_ChannelOutboundHandler.html#/s:3NIO23_ChannelOutboundHandlerP4read7contextyAA0bD7ContextC_tF) event.
+
+By default, `Channel`s in SwiftNIO have the [`autoRead`](https://apple.github.io/swift-nio/docs/current/NIO/Structs/ChannelOptions.html#/s:3NIO14ChannelOptionsV8autoReadAC5TypesO04AutoE6OptionVvpZ)
+`ChannelOption` enabled. When `autoRead` is enabled, SwiftNIO will automatically send a `read` (note, this is a very different event than the
+inbound `channelRead` event that is used to deliver data) event when the previous read burst has
+completed (signalled by the inbound [`channelReadComplete`](https://apple.github.io/swift-nio/docs/current/NIO/Protocols/_ChannelInboundHandler.html#/s:3NIO22_ChannelInboundHandlerP19channelReadComplete7contextyAA0bD7ContextC_tF)
+event). Therefore, you may be unaware of the existance of the `read` event despite having used SwiftNIO before.
+
+Suppressing the `read` event is one of the key demonstrations of this example. The fundamental idea is that to start with we let `read` flow
+through the `ChannelPipeline` until we have an HTTP request and the first bits of its request body. Once we received the first bits of the
+HTTP request body, we will _suppress_ `read` from flowing through the `ChannelPipeline` which means that SwiftNIO will stop reading
+further data from the network.
+When SwiftNIO stops reading further data from the network, this means that TCP flow control will kick in and slow the client down sending
+more of the HTTP request body (once both the client's send and the server's receive buffer are full).
+Once the disk writes of the previously received chunks have completed, we will issue a `read` event (assuming we held up at least one). From
+then on, `read` events will flow freely until the next bit of the HTTP request body is received, when they'll be suppressed again.
+
+This means however fast the client or however slow the disk is, we should be able to stream arbitarily size HTTP request bodies to disk in
+constant memory.
+
+## Example implementation
+
+The implementation in this example creates a state machine called [`FileIOChannelWriteCoordinator.swift`](Sources/FileIOChannelWriteCoordinator.swift)
+which gets notified about the events that happen (both on the `ChannelPipeline` and from `NonBlockingFileIO`). Every input to the state
+machine also returns an `Action` which describes what operation needs to be done next.
+
+The state machine is deliberately implemented completely free of any I/O or any side effects which is why it returns `Action`.
+
+Because the state machine doesn't do any I/O, it's crucial to tell it about any relevant event that happens in the system.
+
+The full set of inputs to the state machine are
+
+
+- Tell the state machine that a new HTTP request started.
+    ```
+    internal mutating func didStartRequest(targetPath: String) -> Action
+    ```
+
+- Tell the state machine that we received more bytes of the request body.
+    ```
+    internal mutating func didReceiveRequestBodyBytes(_ bytes: ByteBuffer) -> Action
+    ```
+
+- Tell the state machine we received the HTTP request end.
+    ```
+    internal mutating func didReceiveRequestEnd() -> Action
+    ```
+
+- Tell the state machine that we've just finished writing one previously received chunk of the HTTP request body to disk.
+    ```
+    internal mutating func didFinishWritingOneChunkToFile() -> Action
+    ```
+    
+-  Tell the state machine we finished opening the target file.
+    ```
+    internal mutating func didOpenTargetFile(_ fileHandle: NIOFileHandle) -> Action
+    ```
+    
+- Tell the state machine that we've hit an error.
+    ```
+    internal mutating func didError(_ error: Error) -> Action
+    ```
+
+The `Action` returned by the state machine is one of
+
+- Do nothing, we are waiting for some event: `case nothingWeAreWaiting`
+- Start writing chunks to the target file: `case startWritingToTargetFile`
+- Open the file: `case openFile(String)`
+- We are done, please close the file handle. If an error occured, it is sent here too: `case processingCompletedDiscardResources(NIOFileHandle?, Error?)`
+- Just close the file, we have previously completed processing: `case closeFile(NIOFileHandle)`
+
+`SaveEverythingHTTPHandler` is the `ChannelHandler` which drives the state machines with the events it receives through the
+`ChannelPipeline`. Additionally, it tells the state machine about the results of the I/O operations it starts (when `Action` tells it to).

--- a/backpressure-file-io-channel/README.md
+++ b/backpressure-file-io-channel/README.md
@@ -2,7 +2,7 @@
 
 This example shows how you can propagate backpressure from the file system into the Channel.
 
-First, let's establish what it means to propagate backpressure from the file system into the Channel: Let's assume we have a HTTP server
+First, let's establish what it means to propagate backpressure from the file system into the Channel. Let's assume we have a HTTP server
 that accepts arbitrary amounts of data and writes it to the file system. If data is received faster over the network than we can write it to the
 disk, then the server runs into trouble: It can now only either buffer the data in memory or (at least in theory) drop it on the floor. The former
 would easily be usable as a denial of service exploit, the latter means that the server isn't able to provide its core functioniality.

--- a/backpressure-file-io-channel/README.md
+++ b/backpressure-file-io-channel/README.md
@@ -15,7 +15,7 @@ to send further data.
 
 ## Backpressure in SwiftNIO
 
-In SwiftNIO, backpressure is propagated by stopping to call the outbound [`read`](https://apple.github.io/swift-nio/docs/current/NIO/Protocols/_ChannelOutboundHandler.html#/s:3NIO23_ChannelOutboundHandlerP4read7contextyAA0bD7ContextC_tF) event.
+In SwiftNIO, backpressure is propagated by stopping calls to the outbound [`read`](https://apple.github.io/swift-nio/docs/current/NIO/Protocols/_ChannelOutboundHandler.html#/s:3NIO23_ChannelOutboundHandlerP4read7contextyAA0bD7ContextC_tF) event.
 
 By default, `Channel`s in SwiftNIO have the [`autoRead`](https://apple.github.io/swift-nio/docs/current/NIO/Structs/ChannelOptions.html#/s:3NIO14ChannelOptionsV8autoReadAC5TypesO04AutoE6OptionVvpZ)
 `ChannelOption` enabled. When `autoRead` is enabled, SwiftNIO will automatically send a `read` (note, this is a very different event than the

--- a/backpressure-file-io-channel/README.md
+++ b/backpressure-file-io-channel/README.md
@@ -7,7 +7,7 @@ that accepts arbitrary amounts of data and writes it to the file system. If data
 disk, then the server runs into trouble: It can now only either buffer the data in memory or (at least in theory) drop it on the floor. The former
 would easily be usable as a denial of service exploit, the latter means that the server isn't able to provide its core functioniality.
 
-Backpressure is the mechanism to the the buffering issue above. The idea is that the server stops accepting more data from the client than
+Backpressure is the mechanism to resolve the the buffering issue above. The idea is that the server stops accepting more data from the client than
 it can write to disk. Because HTTP runs over TCP which has flow-control built in, the TCP stacks will then lower the server's receive window
 size which means that the client gets slowed down of completely stopped from sending any data. Once the server finishes writing previously
 received data to disk, it starts draining the receive buffer which then make TCP's flow control raise the window sizes which allows the client

--- a/backpressure-file-io-channel/README.md
+++ b/backpressure-file-io-channel/README.md
@@ -9,7 +9,7 @@ would easily be usable as a denial of service exploit, the latter means that the
 
 Backpressure is the mechanism to resolve the the buffering issue above. The idea is that the server stops accepting more data from the client than
 it can write to disk. Because HTTP runs over TCP which has flow-control built in, the TCP stacks will then lower the server's receive window
-size which means that the client gets slowed down of completely stopped from sending any data. Once the server finishes writing previously
+size which means that the client gets slowed down or completely stopped from sending any data. Once the server finishes writing previously
 received data to disk, it starts draining the receive buffer which then make TCP's flow control raise the window sizes which allows the client
 to send further data.
 

--- a/backpressure-file-io-channel/README.md
+++ b/backpressure-file-io-channel/README.md
@@ -21,7 +21,7 @@ By default, `Channel`s in SwiftNIO have the [`autoRead`](https://apple.github.io
 `ChannelOption` enabled. When `autoRead` is enabled, SwiftNIO will automatically send a `read` (note, this is a very different event than the
 inbound `channelRead` event that is used to deliver data) event when the previous read burst has
 completed (signalled by the inbound [`channelReadComplete`](https://apple.github.io/swift-nio/docs/current/NIO/Protocols/_ChannelInboundHandler.html#/s:3NIO22_ChannelInboundHandlerP19channelReadComplete7contextyAA0bD7ContextC_tF)
-event). Therefore, you may be unaware of the existance of the `read` event despite having used SwiftNIO before.
+event). Therefore, you may be unaware of the existence of the `read` event despite having used SwiftNIO before.
 
 Suppressing the `read` event is one of the key demonstrations of this example. The fundamental idea is that to start with we let `read` flow
 through the `ChannelPipeline` until we have an HTTP request and the first bits of its request body. Once we received the first bits of the

--- a/backpressure-file-io-channel/Sources/BackpressureChannelToFileIO/FileIOChannelWriteCoordinator.swift
+++ b/backpressure-file-io-channel/Sources/BackpressureChannelToFileIO/FileIOChannelWriteCoordinator.swift
@@ -1,0 +1,241 @@
+import NIO
+
+internal struct FileIOCoordinatorState {
+    /// The actions for the driver of the state machine to perform.
+    internal struct Action {
+        enum MainAction {
+            /// Do nothing, we are waiting for some event.
+            case nothingWeAreWaiting
+
+            /// Start writing chunks to the target file.
+            case startWritingToTargetFile
+
+            /// Open the file.
+            case openFile(String)
+
+            /// We are done, please close the file handle. If an error occured, it is sent here too.
+            case processingCompletedDiscardResources(NIOFileHandle?, Error?)
+
+            /// Just close the file, we have previously completed processing.
+            case closeFile(NIOFileHandle)
+        }
+
+        /// The main action to perform.
+        var main: MainAction
+
+        /// Apart from the main action, do we also need to call `context.read()`?
+        var callRead: Bool
+    }
+
+    private enum State {
+        struct BufferState {
+            var bufferedWrites: CircularBuffer<ByteBuffer>
+            var heldUpRead: Bool
+            var seenRequestEnd: Bool
+
+            mutating func append(_ buffer: ByteBuffer) {
+                self.bufferedWrites.append(buffer)
+            }
+
+            var isEmpty: Bool {
+                return self.bufferedWrites.isEmpty
+            }
+
+            mutating func removeFirst() -> ByteBuffer {
+                return self.bufferedWrites.removeFirst()
+            }
+        }
+        case idle
+        case openingFile(BufferState)
+        case writing(NIOFileHandle, BufferState)
+        case readyToWrite(NIOFileHandle, BufferState)
+        case error(Error)
+    }
+
+    private var state = State.idle
+
+    private func illegalTransition(_ function: String = #function) -> Never {
+        preconditionFailure("illegal transition \(function) in \(self)")
+    }
+}
+
+// MARK: - State machine inputs
+extension FileIOCoordinatorState {
+    /// Tell the state machine that a new request started.
+    internal mutating func didStartRequest(targetPath: String) -> Action {
+        switch self.state {
+        case .idle:
+            self.state = .openingFile(.init(bufferedWrites: [], heldUpRead: false, seenRequestEnd: false))
+            return Action(main: .openFile(targetPath), callRead: false)
+        case .error:
+            return Action(main: .nothingWeAreWaiting /* for the channel to go away */, callRead: false)
+        default:
+            self.illegalTransition()
+        }
+    }
+
+    /// Tell the state machine that we received more bytes of the request body.
+    internal mutating func didReceiveRequestBodyBytes(_ bytes: ByteBuffer) -> Action {
+        switch self.state {
+        case .idle:
+            self.illegalTransition()
+        case .openingFile(var buffers):
+            buffers.append(bytes)
+            self.state = .openingFile(buffers)
+        case .readyToWrite(let fileHandle, var buffers):
+            buffers.append(bytes)
+            self.state = .writing(fileHandle, buffers)
+            return Action(main: .startWritingToTargetFile, callRead: false)
+        case .writing(let fileHandle, var buffers):
+            buffers.append(bytes)
+            self.state = .writing(fileHandle, buffers)
+        case .error:
+            ()
+        }
+        return Action(main: .nothingWeAreWaiting /* for the file to open or the previous writes to complete */,
+                      callRead: false)
+    }
+
+    /// Tell the state machine that we've just finished writing one chunk.
+    internal mutating func didFinishWritingOneChunkToFile() -> Action {
+        switch self.state {
+        case .idle, .openingFile, .readyToWrite:
+            self.illegalTransition()
+        case .writing(let fileHandle, var buffers):
+            if buffers.isEmpty {
+                let heldUpRead = buffers.heldUpRead
+                buffers.heldUpRead = false
+                if buffers.seenRequestEnd {
+                    self.state = .idle
+                    return Action(main: .processingCompletedDiscardResources(fileHandle, nil), callRead: heldUpRead)
+                } else {
+                    self.state = .readyToWrite(fileHandle, buffers)
+                    return Action(main: .nothingWeAreWaiting /* for more data or EOF */, callRead: heldUpRead)
+                }
+            } else {
+                self.state = .writing(fileHandle, buffers)
+                return Action(main: .startWritingToTargetFile, callRead: false)
+            }
+        case .error:
+            return Action(main: .nothingWeAreWaiting /* for the channel to go away */, callRead: false)
+        }
+    }
+
+    /// Tell the state machine we received the HTTP request end.
+    internal mutating func didReceiveRequestEnd() -> Action {
+        switch self.state {
+        case .idle:
+            self.illegalTransition()
+        case .openingFile(var buffers):
+            precondition(!buffers.seenRequestEnd, "double .end received")
+            buffers.seenRequestEnd = true
+            self.state = .openingFile(buffers)
+        case .readyToWrite(let fileHandle, var buffers):
+            precondition(!buffers.seenRequestEnd, "double .end received")
+            buffers.seenRequestEnd = true
+            if buffers.isEmpty {
+                self.state = .idle
+                return Action(main: .processingCompletedDiscardResources(fileHandle, nil), callRead: buffers.heldUpRead)
+            } else {
+                self.illegalTransition()
+            }
+        case .writing(let fileHandle, var buffers):
+            precondition(!buffers.seenRequestEnd, "double .end received")
+            buffers.seenRequestEnd = true
+            self.state = .writing(fileHandle, buffers)
+        case .error:
+            ()
+        }
+        return Action(main: .nothingWeAreWaiting /* for the writes to the file to complete */, callRead: false)
+    }
+
+    /// Tell the state machine we finished opening the target file.
+    internal mutating func didOpenTargetFile(_ fileHandle: NIOFileHandle) -> Action {
+        switch self.state {
+        case .idle, .readyToWrite, .writing:
+            self.illegalTransition()
+        case .openingFile(let buffers):
+            if buffers.isEmpty {
+                if buffers.seenRequestEnd {
+                    // That's a zero length file
+                    self.state = .idle
+                    return Action(main: .processingCompletedDiscardResources(fileHandle, nil), callRead: buffers.heldUpRead)
+                } else {
+                    self.state = .readyToWrite(fileHandle, buffers)
+                    return Action(main: .nothingWeAreWaiting /* for more data or EOF */, callRead: buffers.heldUpRead)
+                }
+            } else {
+                self.state = .writing(fileHandle, buffers)
+                return Action(main: .startWritingToTargetFile, callRead: false)
+            }
+        case .error:
+            return Action(main: .closeFile(fileHandle), callRead: false)
+        }
+    }
+
+    /// Tell the state machine that we've hit an error.
+    internal mutating func didError(_ error: Error) -> Action {
+        let oldState = self.state
+        self.state = .error(error)
+        switch oldState {
+        case .idle, .error:
+            return Action(main: .nothingWeAreWaiting /* for a new request / the channel to go away */, callRead: false)
+        case .openingFile:
+            return Action(main: .processingCompletedDiscardResources(nil, error), callRead: false)
+        case .readyToWrite(let fileHandle, _), .writing(let fileHandle, _):
+            return Action(main: .processingCompletedDiscardResources(fileHandle, error), callRead: false)
+        }
+    }
+}
+
+// MARK: - State machine queries
+extension FileIOCoordinatorState {
+    /// Are we in a final state of the state machine? Mostly useful to catch bugs.
+    internal var inFinalState: Bool {
+        switch self.state {
+        case .idle, .error:
+            return true
+        default:
+            return false
+        }
+    }
+
+    /// Should we read more data from the network to make further progress?
+    internal mutating func shouldWeReadMoreDataFromNetwork() -> Bool {
+        switch self.state {
+        case .idle, .readyToWrite:
+            // Yes, we're idle or waiting to write the next chunk so more data would be useful.
+            return true
+        case .openingFile(var buffers):
+            // No, we're waiting for the target file to open.
+            buffers.heldUpRead = true
+            self.state = .openingFile(buffers)
+            return false
+        case .writing(let fileHandle, var buffers):
+            // No, we're already writing what we received before.
+            buffers.heldUpRead = true
+            self.state = .writing(fileHandle, buffers)
+            return false
+        case .error:
+            // No, hit an error.
+            return false
+        }
+    }
+
+    internal mutating func pullNextChunkToWrite() -> (NIOFileHandle, ByteBuffer) {
+        switch self.state {
+        case .error, .idle, .openingFile, .readyToWrite:
+            self.illegalTransition()
+        case .writing(let fileHandle, var buffers):
+            let first = buffers.removeFirst()
+            self.state = .writing(fileHandle, buffers)
+            return (fileHandle, first)
+        }
+    }
+}
+
+extension FileIOCoordinatorState: CustomStringConvertible {
+    var description: String {
+        return "\(self.state)"
+    }
+}

--- a/backpressure-file-io-channel/Sources/BackpressureChannelToFileIO/SaveEverythingHTTPServer.swift
+++ b/backpressure-file-io-channel/Sources/BackpressureChannelToFileIO/SaveEverythingHTTPServer.swift
@@ -1,0 +1,164 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2017-2018 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import NIO
+import NIOHTTP1
+import Logging
+
+final class SaveEverythingHTTPServer {
+    private var state = FileIOCoordinatorState() {
+        didSet {
+            self.logger.trace("new state \(self.state)")
+        }
+    }
+
+    private let fileIO: NonBlockingFileIO
+    internal var logger: Logger
+
+    init(fileIO: NonBlockingFileIO, logger: Logger? = nil) {
+        self.fileIO = fileIO
+        if let logger = logger {
+            self.logger = logger
+        } else {
+            self.logger = Logger(label: "\(#file)")
+        }
+    }
+}
+
+// MARK: - The handler for the Actions the state machine recommends to do
+extension SaveEverythingHTTPServer {
+    func runAction(_ action: FileIOCoordinatorState.Action, context: ChannelHandlerContext) {
+        self.logger.trace("doing action \(action)")
+        switch action.main {
+        case .closeFile(let fileHandle):
+            try! fileHandle.close()
+        case .processingCompletedDiscardResources(let fileHandle, let maybeError):
+            try! fileHandle?.close()
+            self.logger.debug("fully handled request: \(maybeError.debugDescription)")
+            self.requestFullyProcessed(context: context, result: maybeError.map { .failure($0) } ?? .success(()))
+        case .openFile(let path):
+            self.fileIO.openFile(path: path,
+                                 mode: .write,
+                                 flags: .allowFileCreation(posixMode: 0o600),
+                                 eventLoop: context.eventLoop).flatMap { fileHandle in
+                        self.fileIO.changeFileSize(fileHandle: fileHandle,
+                                                   size: 0,
+                                                   eventLoop: context.eventLoop).map { fileHandle }
+            }.whenComplete { result in
+                switch result {
+                case .success(let fileHandle):
+                    self.runAction(self.state.didOpenTargetFile(fileHandle),
+                                   context: context)
+                case .failure(let error):
+                    self.runAction(self.state.didError(error),
+                                   context: context)
+                }
+            }
+        case .nothingWeAreWaiting:
+            ()
+        case .startWritingToTargetFile:
+            let (fileHandle, bytes) = self.state.pullNextChunkToWrite()
+            self.fileIO.write(fileHandle: fileHandle, buffer: bytes, eventLoop: context.eventLoop).whenComplete { result in
+                switch result {
+                case .success(()):
+                    self.runAction(self.state.didFinishWritingOneChunkToFile(), context: context)
+                case .failure(let error):
+                    self.runAction(self.state.didError(error), context: context)
+                }
+            }
+        }
+        if action.callRead {
+            context.read()
+        }
+    }
+}
+
+// MARK: - Finishing the request
+extension SaveEverythingHTTPServer {
+    func requestFullyProcessed(context: ChannelHandlerContext, result: Result<Void, Error>) {
+        switch result {
+        case .success:
+            context.write(self.wrapOutboundOut(HTTPServerResponsePart.head(.init(version: .init(major: 1,
+                                                                                                minor: 1),
+                                                                                 status: .ok))),
+                          promise: nil)
+            context.writeAndFlush(self.wrapOutboundOut(HTTPServerResponsePart.end(nil)), promise: nil)
+        case .failure(let error):
+            let errorPage = "ERROR on \(context.channel): \(error)"
+            context.write(self.wrapOutboundOut(HTTPServerResponsePart.head(.init(version: .init(major: 1,
+                                                                                                minor: 1),
+                                                                                 status: .internalServerError,
+                                                                                 headers: ["connection": "close",
+                                                                                           "content-length": "\(errorPage.utf8.count)"]))),
+                          promise: nil)
+            var buffer = context.channel.allocator.buffer(capacity: errorPage.utf8.count)
+            buffer.writeString(errorPage)
+            context.write(self.wrapOutboundOut(HTTPServerResponsePart.body(.byteBuffer(buffer))), promise: nil)
+            context.writeAndFlush(self.wrapOutboundOut(HTTPServerResponsePart.end(nil))).whenComplete { _ in
+                context.close(promise: nil)
+            }
+        }
+    }
+}
+
+// MARK: - ChannelHandler conformance
+extension SaveEverythingHTTPServer: ChannelDuplexHandler {
+    typealias InboundIn = HTTPServerRequestPart
+    typealias OutboundIn = Never
+    typealias OutboundOut = HTTPServerResponsePart
+
+    func errorCaught(context: ChannelHandlerContext, error: Error) {
+        self.logger.info("error on channel: \(error)")
+        self.runAction(self.state.didError(error), context: context)
+    }
+
+    func channelRead(context: ChannelHandlerContext, data: NIOAny) {
+        let reqPart = self.unwrapInboundIn(data)
+
+        switch reqPart {
+        case .head(let request):
+            self.runAction(self.state.didStartRequest(targetPath: self.filenameForURI(request.uri)), context: context)
+        case .body(let bytes):
+            self.runAction(self.state.didReceiveRequestBodyBytes(bytes), context: context)
+        case .end:
+            self.runAction(self.state.didReceiveRequestEnd(), context: context)
+        }
+    }
+
+    func read(context: ChannelHandlerContext) {
+        if self.state.shouldWeReadMoreDataFromNetwork() {
+            context.read()
+        }
+    }
+
+    func handlerRemoved(context: ChannelHandlerContext) {
+        assert(self.state.inFinalState, "illegal state on handler removal: \(self.state)")
+    }
+}
+
+// MARK: - Helpers
+extension SaveEverythingHTTPServer {
+    func filenameForURI(_ uri: String) -> String {
+        var result = "/tmp/uploaded_file_"
+        result.append(contentsOf: uri.map { char in
+            switch char {
+            case "A" ... "Z", "a" ... "z", "0" ... "9":
+                return char
+            default:
+                return "_"
+            }
+        })
+        return result
+    }
+}

--- a/backpressure-file-io-channel/Sources/BackpressureChannelToFileIO/main.swift
+++ b/backpressure-file-io-channel/Sources/BackpressureChannelToFileIO/main.swift
@@ -1,0 +1,46 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2017-2018 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import NIO
+import NIOHTTP1
+import Logging
+
+let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+defer {
+    try! group.syncShutdownGracefully()
+}
+
+let threadPool = NIOThreadPool(numberOfThreads: 1)
+threadPool.start()
+defer {
+    try! threadPool.syncShutdownGracefully()
+}
+
+let fileIO = NonBlockingFileIO(threadPool: threadPool)
+
+var logger = Logger(label: "BackpressureChannelToFileIO")
+logger.logLevel = .trace
+let server = try ServerBootstrap(group: group)
+        .serverChannelOption(ChannelOptions.socket(.init(SOL_SOCKET), .init(SO_REUSEADDR)), value: 1)
+        .childChannelInitializer { [logger] channel in
+            var logger = logger
+            logger[metadataKey: "connection"] = "\(channel.remoteAddress!)"
+            return channel.pipeline.configureHTTPServerPipeline(withErrorHandling: false).flatMap {
+                channel.pipeline.addHandler(SaveEverythingHTTPServer(fileIO: fileIO, logger: logger))
+            }
+        }
+        .bind(host: "localhost", port: 8080)
+        .wait()
+logger.info("Server up and running at \(server.localAddress!)")
+try! server.closeFuture.wait()


### PR DESCRIPTION
Gluing together two (incompatible) asynchronous pieces is hard. We often tell people to propagate backpressure from the Channel into the file system but never made a great example (I think). This is supposed to fix this.