### PR TITLE
Basic working connection limiter

### DIFF
--- a/connection-limiter/.gitignore
+++ b/connection-limiter/.gitignore
@@ -1,0 +1,7 @@
+.DS_Store
+/.build
+/Packages
+/*.xcodeproj
+xcuserdata/
+DerivedData/
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata

--- a/connection-limiter/Package.swift
+++ b/connection-limiter/Package.swift
@@ -1,0 +1,23 @@
+// swift-tools-version:5.2
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "connection-limiter",
+    dependencies: [
+        .package(name: "swift-nio", url: "https://github.com/apple/swift-nio", from: "2.16.0")
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
+        // Targets can depend on other targets in this package, and on products in packages which this package depends on.
+        .target(
+            name: "connection-limiter",
+            dependencies: [
+                .product(name: "NIO", package: "swift-nio")
+            ]),
+        .testTarget(
+            name: "connection-limiterTests",
+            dependencies: ["connection-limiter"]),
+    ]
+)

--- a/connection-limiter/README.md
+++ b/connection-limiter/README.md
@@ -1,0 +1,3 @@
+# connection-limiter
+
+A description of this package.

--- a/connection-limiter/Sources/connection-limiter/main.swift
+++ b/connection-limiter/Sources/connection-limiter/main.swift
@@ -1,0 +1,64 @@
+
+import NIO
+
+class LimitHandler: ChannelDuplexHandler {
+    
+    typealias OutboundIn = Channel
+    typealias InboundIn = Channel
+    
+    let connectionLimit: Int
+    var currentConnections = 0
+    
+    init(connectionLimit: Int) {
+        self.connectionLimit = connectionLimit
+    }
+    
+    func channelRead(context: ChannelHandlerContext, data: NIOAny) {
+        let channel = self.unwrapInboundIn(data)
+        context.fireChannelRead(data)
+        self.currentConnections += 1
+        channel.closeFuture.whenSuccess {
+            context.read()
+        }
+    }
+    
+    func read(context: ChannelHandlerContext) {
+        guard self.currentConnections < self.connectionLimit else {
+            return
+        }
+        context.read()
+    }
+    
+}
+
+class EchoChannelHandler: ChannelInboundHandler {
+    
+    typealias InboundIn = ByteBuffer
+    typealias InboundOut = ByteBuffer
+    
+    func channelRead(context: ChannelHandlerContext, data: NIOAny) {
+        var input = self.unwrapInboundIn(data)
+        var buffer = context.channel.allocator.buffer(capacity: input.readableBytes + 6)
+        buffer.writeString("Echo: ")
+        buffer.writeBuffer(&input)
+        let output = self.wrapInboundOut(buffer)
+        context.writeAndFlush(output, promise: nil)
+    }
+    
+}
+
+let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+try ServerBootstrap(group: group)
+.serverChannelInitializer({ (channel) -> EventLoopFuture<Void> in
+    channel.pipeline.addHandler(LimitHandler(connectionLimit: 1))
+})
+.serverChannelOption(ChannelOptions.maxMessagesPerRead, value: 1)
+.serverChannelOption(ChannelOptions.backlog, value: 1)
+.childChannelInitializer { (channel) -> EventLoopFuture<Void> in
+    channel.pipeline.addHandler(EchoChannelHandler())
+}
+.serverChannelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR), value: 1)
+.bind(host: "127.0.0.1", port: 4321)
+.wait()
+.closeFuture
+.wait()

--- a/connection-limiter/Tests/LinuxMain.swift
+++ b/connection-limiter/Tests/LinuxMain.swift
@@ -1,0 +1,7 @@
+import XCTest
+
+import connection_limiterTests
+
+var tests = [XCTestCaseEntry]()
+tests += connection_limiterTests.allTests()
+XCTMain(tests)

--- a/connection-limiter/Tests/connection-limiterTests/XCTestManifests.swift
+++ b/connection-limiter/Tests/connection-limiterTests/XCTestManifests.swift
@@ -1,0 +1,9 @@
+import XCTest
+
+#if !canImport(ObjectiveC)
+public func allTests() -> [XCTestCaseEntry] {
+    return [
+        testCase(connection_limiterTests.allTests),
+    ]
+}
+#endif

--- a/connection-limiter/Tests/connection-limiterTests/connection_limiterTests.swift
+++ b/connection-limiter/Tests/connection-limiterTests/connection_limiterTests.swift
@@ -1,0 +1,6 @@
+import XCTest
+import class Foundation.Bundle
+
+final class connection_limiterTests: XCTestCase {
+    
+}


### PR DESCRIPTION
Example of a (very) simple echo server that only allows `n` active connections at any one time.