### PR TITLE
BackpressureChannelFileIO: Show example tests & fix bug

### DIFF
--- a/backpressure-file-io-channel/Package.swift
+++ b/backpressure-file-io-channel/Package.swift
@@ -11,5 +11,10 @@ let package = Package(
         .target(
             name: "BackpressureChannelToFileIO",
             dependencies: ["NIO", "NIOHTTP1", "Logging"]),
+        .target(
+            name: "BackpressureChannelToFileIODemo",
+            dependencies: ["NIO", "BackpressureChannelToFileIO", "Logging"]),
+        .testTarget(name: "BackpressureChannelToFileIOTests",
+                    dependencies: ["NIO", "BackpressureChannelToFileIO"]),
     ]
 )

--- a/backpressure-file-io-channel/README.md
+++ b/backpressure-file-io-channel/README.md
@@ -50,7 +50,7 @@ The full set of inputs to the state machine are
 
 - Tell the state machine that a new HTTP request started.
     ```
-    internal mutating func didStartRequest(targetPath: String) -> Action
+    internal mutating func didReceiveRequestBegin(targetPath: String) -> Action
     ```
 
 - Tell the state machine that we received more bytes of the request body.

--- a/backpressure-file-io-channel/Sources/BackpressureChannelToFileIO/FileIOChannelWriteCoordinator.swift
+++ b/backpressure-file-io-channel/Sources/BackpressureChannelToFileIO/FileIOChannelWriteCoordinator.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftNIO open source project
 //
-// Copyright (c) 2017-2018 Apple Inc. and the SwiftNIO project authors
+// Copyright (c) 2020 Apple Inc. and the SwiftNIO project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/backpressure-file-io-channel/Sources/BackpressureChannelToFileIO/FileIOChannelWriteCoordinator.swift
+++ b/backpressure-file-io-channel/Sources/BackpressureChannelToFileIO/FileIOChannelWriteCoordinator.swift
@@ -1,3 +1,17 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2017-2018 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
 import NIO
 
 internal struct FileIOCoordinatorState {
@@ -45,10 +59,24 @@ internal struct FileIOCoordinatorState {
                 return self.bufferedWrites.removeFirst()
             }
         }
+
+        /// We're totally idle, waiting for the next request.
         case idle
+
+        /// We commanded a file to be opened, now waiting for that to happen.
         case openingFile(BufferState)
+
+        /// We commanded a write to disk to happen, now waiting for that to complete.
         case writing(NIOFileHandle, BufferState)
+
+        /// We're waiting for someone to pull the next bit of data (to then be written to disk).
         case readyToWrite(NIOFileHandle, BufferState)
+
+        /// We encountered an error during a disk write. We must sit on this for a bit until the disk write completes,
+        /// then we can discard the resources and close the file handle (which must not happen during writes).
+        case errorWhilstWriting(NIOFileHandle, Error)
+
+        /// We're in an error state, hold no resources, and will never recover. We'll stay here until we are no more.
         case error(Error)
     }
 
@@ -62,7 +90,7 @@ internal struct FileIOCoordinatorState {
 // MARK: - State machine inputs
 extension FileIOCoordinatorState {
     /// Tell the state machine that a new request started.
-    internal mutating func didStartRequest(targetPath: String) -> Action {
+    internal mutating func didReceiveRequestBegin(targetPath: String) -> Action {
         switch self.state {
         case .idle:
             self.state = .openingFile(.init(bufferedWrites: [], heldUpRead: false, seenRequestEnd: false))
@@ -84,12 +112,13 @@ extension FileIOCoordinatorState {
             self.state = .openingFile(buffers)
         case .readyToWrite(let fileHandle, var buffers):
             buffers.append(bytes)
+            // We go straight to `.writing` because we expect the driver to pull the next chunk using `pullNextChunk`.
             self.state = .writing(fileHandle, buffers)
             return Action(main: .startWritingToTargetFile, callRead: false)
         case .writing(let fileHandle, var buffers):
             buffers.append(bytes)
             self.state = .writing(fileHandle, buffers)
-        case .error:
+        case .error, .errorWhilstWriting:
             ()
         }
         return Action(main: .nothingWeAreWaiting /* for the file to open or the previous writes to complete */,
@@ -116,8 +145,12 @@ extension FileIOCoordinatorState {
                 self.state = .writing(fileHandle, buffers)
                 return Action(main: .startWritingToTargetFile, callRead: false)
             }
+        case .errorWhilstWriting(let fileHandle, let error):
+            // Okay, the write finally completed, let's discard the resources.
+            self.state = .error(error)
+            return Action(main: .processingCompletedDiscardResources(fileHandle, error), callRead: false)
         case .error:
-            return Action(main: .nothingWeAreWaiting /* for the channel to go away */, callRead: false)
+            self.illegalTransition() // if an error happened whilst writing then we should be in the above case.
         }
     }
 
@@ -135,7 +168,9 @@ extension FileIOCoordinatorState {
             buffers.seenRequestEnd = true
             if buffers.isEmpty {
                 self.state = .idle
-                return Action(main: .processingCompletedDiscardResources(fileHandle, nil), callRead: buffers.heldUpRead)
+                let heldUpRead = buffers.heldUpRead
+                buffers.heldUpRead = false // because we're delivering it now.
+                return Action(main: .processingCompletedDiscardResources(fileHandle, nil), callRead: heldUpRead)
             } else {
                 self.illegalTransition()
             }
@@ -143,7 +178,7 @@ extension FileIOCoordinatorState {
             precondition(!buffers.seenRequestEnd, "double .end received")
             buffers.seenRequestEnd = true
             self.state = .writing(fileHandle, buffers)
-        case .error:
+        case .error, .errorWhilstWriting:
             ()
         }
         return Action(main: .nothingWeAreWaiting /* for the writes to the file to complete */, callRead: false)
@@ -152,17 +187,19 @@ extension FileIOCoordinatorState {
     /// Tell the state machine we finished opening the target file.
     internal mutating func didOpenTargetFile(_ fileHandle: NIOFileHandle) -> Action {
         switch self.state {
-        case .idle, .readyToWrite, .writing:
+        case .idle, .readyToWrite, .writing, .errorWhilstWriting:
             self.illegalTransition()
-        case .openingFile(let buffers):
+        case .openingFile(var buffers):
+            let heldUpRead = buffers.heldUpRead
+            buffers.heldUpRead = false // because we're replaying it now.
             if buffers.isEmpty {
                 if buffers.seenRequestEnd {
                     // That's a zero length file
                     self.state = .idle
-                    return Action(main: .processingCompletedDiscardResources(fileHandle, nil), callRead: buffers.heldUpRead)
+                    return Action(main: .processingCompletedDiscardResources(fileHandle, nil), callRead: heldUpRead)
                 } else {
                     self.state = .readyToWrite(fileHandle, buffers)
-                    return Action(main: .nothingWeAreWaiting /* for more data or EOF */, callRead: buffers.heldUpRead)
+                    return Action(main: .nothingWeAreWaiting /* for more data or EOF */, callRead: heldUpRead)
                 }
             } else {
                 self.state = .writing(fileHandle, buffers)
@@ -178,12 +215,15 @@ extension FileIOCoordinatorState {
         let oldState = self.state
         self.state = .error(error)
         switch oldState {
-        case .idle, .error:
+        case .idle, .error, .errorWhilstWriting:
             return Action(main: .nothingWeAreWaiting /* for a new request / the channel to go away */, callRead: false)
         case .openingFile:
             return Action(main: .processingCompletedDiscardResources(nil, error), callRead: false)
-        case .readyToWrite(let fileHandle, _), .writing(let fileHandle, _):
+        case .readyToWrite(let fileHandle, _):
             return Action(main: .processingCompletedDiscardResources(fileHandle, error), callRead: false)
+        case .writing(let fileHandle, _):
+            self.state = .errorWhilstWriting(fileHandle, error)
+            return Action(main: .nothingWeAreWaiting /* for the write to complete */, callRead: false)
         }
     }
 }
@@ -216,7 +256,7 @@ extension FileIOCoordinatorState {
             buffers.heldUpRead = true
             self.state = .writing(fileHandle, buffers)
             return false
-        case .error:
+        case .error, .errorWhilstWriting:
             // No, hit an error.
             return false
         }
@@ -224,7 +264,7 @@ extension FileIOCoordinatorState {
 
     internal mutating func pullNextChunkToWrite() -> (NIOFileHandle, ByteBuffer) {
         switch self.state {
-        case .error, .idle, .openingFile, .readyToWrite:
+        case .error, .idle, .openingFile, .readyToWrite, .errorWhilstWriting:
             self.illegalTransition()
         case .writing(let fileHandle, var buffers):
             let first = buffers.removeFirst()

--- a/backpressure-file-io-channel/Sources/BackpressureChannelToFileIO/SaveEverythingHTTPServer.swift
+++ b/backpressure-file-io-channel/Sources/BackpressureChannelToFileIO/SaveEverythingHTTPServer.swift
@@ -16,7 +16,7 @@ import NIO
 import NIOHTTP1
 import Logging
 
-final class SaveEverythingHTTPServer {
+public final class SaveEverythingHTTPServer {
     private var state = FileIOCoordinatorState() {
         didSet {
             self.logger.trace("new state \(self.state)")
@@ -26,7 +26,7 @@ final class SaveEverythingHTTPServer {
     private let fileIO: NonBlockingFileIO
     internal var logger: Logger
 
-    init(fileIO: NonBlockingFileIO, logger: Logger? = nil) {
+    public init(fileIO: NonBlockingFileIO, logger: Logger? = nil) {
         self.fileIO = fileIO
         if let logger = logger {
             self.logger = logger
@@ -114,21 +114,21 @@ extension SaveEverythingHTTPServer {
 
 // MARK: - ChannelHandler conformance
 extension SaveEverythingHTTPServer: ChannelDuplexHandler {
-    typealias InboundIn = HTTPServerRequestPart
-    typealias OutboundIn = Never
-    typealias OutboundOut = HTTPServerResponsePart
+    public typealias InboundIn = HTTPServerRequestPart
+    public typealias OutboundIn = Never
+    public typealias OutboundOut = HTTPServerResponsePart
 
-    func errorCaught(context: ChannelHandlerContext, error: Error) {
+    public func errorCaught(context: ChannelHandlerContext, error: Error) {
         self.logger.info("error on channel: \(error)")
         self.runAction(self.state.didError(error), context: context)
     }
 
-    func channelRead(context: ChannelHandlerContext, data: NIOAny) {
+    public func channelRead(context: ChannelHandlerContext, data: NIOAny) {
         let reqPart = self.unwrapInboundIn(data)
 
         switch reqPart {
         case .head(let request):
-            self.runAction(self.state.didStartRequest(targetPath: self.filenameForURI(request.uri)), context: context)
+            self.runAction(self.state.didReceiveRequestBegin(targetPath: self.filenameForURI(request.uri)), context: context)
         case .body(let bytes):
             self.runAction(self.state.didReceiveRequestBodyBytes(bytes), context: context)
         case .end:
@@ -136,13 +136,13 @@ extension SaveEverythingHTTPServer: ChannelDuplexHandler {
         }
     }
 
-    func read(context: ChannelHandlerContext) {
+    public func read(context: ChannelHandlerContext) {
         if self.state.shouldWeReadMoreDataFromNetwork() {
             context.read()
         }
     }
 
-    func handlerRemoved(context: ChannelHandlerContext) {
+    public func handlerRemoved(context: ChannelHandlerContext) {
         assert(self.state.inFinalState, "illegal state on handler removal: \(self.state)")
     }
 }

--- a/backpressure-file-io-channel/Sources/BackpressureChannelToFileIODemo/main.swift
+++ b/backpressure-file-io-channel/Sources/BackpressureChannelToFileIODemo/main.swift
@@ -13,8 +13,8 @@
 //===----------------------------------------------------------------------===//
 
 import NIO
-import NIOHTTP1
 import Logging
+import BackpressureChannelToFileIO
 
 let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
 defer {

--- a/backpressure-file-io-channel/Tests/BackpressureChannelToFileIOTests/StateMachineTest.swift
+++ b/backpressure-file-io-channel/Tests/BackpressureChannelToFileIOTests/StateMachineTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftNIO open source project
 //
-// Copyright (c) 2017-2018 Apple Inc. and the SwiftNIO project authors
+// Copyright (c) 2020 Apple Inc. and the SwiftNIO project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/backpressure-file-io-channel/Tests/BackpressureChannelToFileIOTests/StateMachineTest.swift
+++ b/backpressure-file-io-channel/Tests/BackpressureChannelToFileIOTests/StateMachineTest.swift
@@ -1,0 +1,505 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2017-2018 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import XCTest
+import NIO
+@testable import BackpressureChannelToFileIO
+
+final class StateMachineTest: XCTestCase {
+    var coordinator: FileIOCoordinatorState!
+
+    func testErrorArrivesWhilstWriting() {
+        XCTAssertTrue(self.coordinator.shouldWeReadMoreDataFromNetwork())
+        self.coordinator.didReceiveRequestBegin(targetPath: "/test")
+            .assertOpenFile({ path in
+                XCTAssertEqual("/test", path)
+            })
+            .assertDoNotCallRead() // We're waiting for the file to open, so we better don't buffer more.
+        XCTAssertFalse(self.coordinator.shouldWeReadMoreDataFromNetwork())
+        self.coordinator.didOpenTargetFile(self.fakeFileHandle)
+            .assertCallRead() // Now, we want the body bytes
+        XCTAssertTrue(self.coordinator.shouldWeReadMoreDataFromNetwork())
+        self.coordinator.didReceiveRequestBodyBytes(self.byteX)
+            .assertStartWriting()
+            .assertDoNotCallRead() // We're now processing them, so let's wait again
+
+        // Now, we're currently `.writing`, so let's inject the error.
+        self.coordinator.didError(DummyError())
+            .assertNothing() // We should be told to do nothing and sit tight.
+            .assertDoNotCallRead()
+
+        // But now, we're done writing which should surface the error:
+        self.coordinator.didFinishWritingOneChunkToFile()
+            .assertDiscardResources({ fileHandle, error in
+                XCTAssertNotNil(fileHandle)
+                XCTAssert(error is DummyError)
+            })
+    }
+
+    func testErrorArrivesWhilstOpeningFile() {
+        XCTAssertTrue(self.coordinator.shouldWeReadMoreDataFromNetwork())
+        self.coordinator.didReceiveRequestBegin(targetPath: "/test")
+            .assertOpenFile({ path in
+                XCTAssertEqual("/test", path)
+            })
+            .assertDoNotCallRead() // We're waiting for the file to open, so we better don't buffer more.
+
+        self.coordinator.didError(DummyError())
+            .assertDiscardResources({ fileHandle, error in
+                XCTAssertNil(fileHandle) // haven't got one yet
+                XCTAssert(error is DummyError)
+            })
+            .assertDoNotCallRead()
+
+        self.coordinator.didOpenTargetFile(self.fakeFileHandle)
+            .assertCloseFile({ fileHandle in
+                XCTAssertNotNil(fileHandle)
+            })
+            .assertDoNotCallRead()
+    }
+
+    func testQuickRunthroughWithoutErrors() {
+        XCTAssertTrue(self.coordinator.shouldWeReadMoreDataFromNetwork())
+        self.coordinator.didReceiveRequestBegin(targetPath: "/")
+            .assertOpenFile({ XCTAssertEqual("/", $0) })
+            .assertDoNotCallRead()
+        XCTAssertFalse(self.coordinator.shouldWeReadMoreDataFromNetwork())
+        self.coordinator.didOpenTargetFile(self.fakeFileHandle)
+            .assertNothing()
+            .assertCallRead()
+        XCTAssertTrue(self.coordinator.shouldWeReadMoreDataFromNetwork())
+        self.coordinator.didReceiveRequestBodyBytes(self.byteX)
+            .assertStartWriting()
+            .assertDoNotCallRead()
+        XCTAssertFalse(self.coordinator.shouldWeReadMoreDataFromNetwork())
+        XCTAssertEqual(self.byteX, self.coordinator.pullNextChunkToWrite().1)
+        XCTAssertFalse(self.coordinator.shouldWeReadMoreDataFromNetwork())
+        self.coordinator.didFinishWritingOneChunkToFile()
+            .assertNothing()
+            .assertCallRead()
+        XCTAssertTrue(self.coordinator.shouldWeReadMoreDataFromNetwork())
+        self.coordinator.didReceiveRequestEnd()
+            .assertDiscardResources({ fileHandle, error in
+                XCTAssertNotNil(fileHandle)
+                XCTAssertNil(error)
+            })
+            .assertDoNotCallRead() // We didn't hold a read, no need to replay one.
+        XCTAssertTrue(self.coordinator.shouldWeReadMoreDataFromNetwork())
+    }
+
+    func testWeBufferCorrectlyEvenIfWeHoldReads() {
+        // Let's kickstart this and go right into the body streaming bit
+        self.moveToBodyStreamingState()
+
+        // Let's get 3 chunks queued up (despite we shouldn't get any)
+        XCTAssertTrue(self.coordinator.shouldWeReadMoreDataFromNetwork())
+        self.coordinator.didReceiveRequestBodyBytes(self.byteX)
+            .assertStartWriting()
+            .assertDoNotCallRead()
+        XCTAssertFalse(self.coordinator.shouldWeReadMoreDataFromNetwork())
+        self.coordinator.didReceiveRequestBodyBytes(self.byteY)
+            .assertNothing()
+            .assertDoNotCallRead()
+        XCTAssertFalse(self.coordinator.shouldWeReadMoreDataFromNetwork())
+        self.coordinator.didReceiveRequestBodyBytes(self.byteX)
+            .assertNothing()
+            .assertDoNotCallRead()
+
+        // Okay, and finally, let's drain one
+        XCTAssertFalse(self.coordinator.shouldWeReadMoreDataFromNetwork())
+        XCTAssertEqual(self.byteX, self.coordinator.pullNextChunkToWrite().1)
+        self.coordinator.didFinishWritingOneChunkToFile()
+            .assertStartWriting()
+            .assertDoNotCallRead()
+
+        // Let's enqueue another one, again we shouldn't have to
+        XCTAssertFalse(self.coordinator.shouldWeReadMoreDataFromNetwork())
+        self.coordinator.didReceiveRequestBodyBytes(self.byteY)
+            .assertNothing()
+            .assertDoNotCallRead()
+
+        // Let's drain them all
+        XCTAssertFalse(self.coordinator.shouldWeReadMoreDataFromNetwork())
+        XCTAssertEqual(self.byteY, self.coordinator.pullNextChunkToWrite().1)
+        self.coordinator.didFinishWritingOneChunkToFile()
+            .assertStartWriting()
+            .assertDoNotCallRead()
+        XCTAssertFalse(self.coordinator.shouldWeReadMoreDataFromNetwork())
+        XCTAssertEqual(self.byteX, self.coordinator.pullNextChunkToWrite().1)
+        self.coordinator.didFinishWritingOneChunkToFile()
+            .assertStartWriting()
+            .assertDoNotCallRead()
+        XCTAssertFalse(self.coordinator.shouldWeReadMoreDataFromNetwork())
+        XCTAssertEqual(self.byteY, self.coordinator.pullNextChunkToWrite().1)
+        self.coordinator.didFinishWritingOneChunkToFile()
+            .assertNothing()
+            .assertCallRead() // Cool, ready for reads again.
+
+        self.moveFromBodyStreamingToEnd(expectError: false)
+    }
+
+    func testBufferingWhilstFileIsOpening() {
+        XCTAssertTrue(self.coordinator.shouldWeReadMoreDataFromNetwork())
+        self.coordinator.didReceiveRequestBegin(targetPath: "/")
+            .assertOpenFile({ XCTAssertEqual("/", $0) })
+            .assertDoNotCallRead()
+
+        // Let's get 2 chunks queued up (despite we shouldn't get any)
+        XCTAssertFalse(self.coordinator.shouldWeReadMoreDataFromNetwork())
+        self.coordinator.didReceiveRequestBodyBytes(self.byteX)
+            .assertNothing()
+            .assertDoNotCallRead()
+        XCTAssertFalse(self.coordinator.shouldWeReadMoreDataFromNetwork())
+        self.coordinator.didReceiveRequestBodyBytes(self.byteY)
+            .assertNothing()
+            .assertDoNotCallRead()
+
+        self.coordinator.didOpenTargetFile(self.fakeFileHandle)
+            .assertStartWriting()
+            .assertDoNotCallRead()
+
+        // Let's drain them all
+        XCTAssertFalse(self.coordinator.shouldWeReadMoreDataFromNetwork())
+        XCTAssertEqual(self.byteX, self.coordinator.pullNextChunkToWrite().1)
+        self.coordinator.didFinishWritingOneChunkToFile()
+            .assertStartWriting()
+            .assertDoNotCallRead()
+        XCTAssertFalse(self.coordinator.shouldWeReadMoreDataFromNetwork())
+        XCTAssertEqual(self.byteY, self.coordinator.pullNextChunkToWrite().1)
+        self.coordinator.didFinishWritingOneChunkToFile()
+            .assertNothing()
+            .assertCallRead()
+
+        self.moveFromBodyStreamingToEnd(expectError: false)
+    }
+
+    func testErrorWhilstWaitingForBytes() {
+        self.moveToBodyStreamingState()
+
+        XCTAssertTrue(self.coordinator.shouldWeReadMoreDataFromNetwork())
+        self.coordinator.didError(DummyError())
+            .assertDiscardResources({ fileHandle, error in
+                XCTAssertNotNil(fileHandle)
+                XCTAssert(error is DummyError)
+            })
+            .assertDoNotCallRead()
+
+        self.moveFromBodyStreamingToEnd(expectError: true)
+    }
+
+    func testErrorWhilstWriting() {
+        self.moveToBodyStreamingState()
+
+        XCTAssertTrue(self.coordinator.shouldWeReadMoreDataFromNetwork())
+        self.coordinator.didReceiveRequestBodyBytes(self.byteX)
+            .assertStartWriting()
+            .assertDoNotCallRead()
+        self.coordinator.didError(DummyError())
+            .assertNothing()
+            .assertDoNotCallRead()
+        self.coordinator.didFinishWritingOneChunkToFile()
+            .assertDiscardResources({ fileHandle, error in
+                XCTAssertNotNil(fileHandle)
+                XCTAssert(error is DummyError)
+            })
+
+        self.moveFromBodyStreamingToEnd(expectError: true)
+    }
+
+
+    func testErrorWhilstIdleButStillReceivingStuff() {
+        self.coordinator.didError(DummyError())
+            .assertNothing()
+            .assertDoNotCallRead()
+
+        self.coordinator.didReceiveRequestBegin(targetPath: "/foo")
+            .assertDoNotCallRead()
+            .assertNothing()
+
+        self.coordinator.didReceiveRequestBodyBytes(self.byteX)
+            .assertDoNotCallRead()
+            .assertNothing()
+
+        self.coordinator.didReceiveRequestEnd()
+            .assertDoNotCallRead()
+            .assertNothing()
+    }
+
+    func testReceiveWholeRequestBeforeFileOpens() {
+        XCTAssertTrue(self.coordinator.shouldWeReadMoreDataFromNetwork())
+        self.coordinator.didReceiveRequestBegin(targetPath: "/")
+            .assertDoNotCallRead()
+            .assertOpenFile({ XCTAssertEqual("/", $0) })
+
+        XCTAssertFalse(self.coordinator.shouldWeReadMoreDataFromNetwork())
+        self.coordinator.didReceiveRequestBodyBytes(self.byteX)
+            .assertNothing()
+            .assertDoNotCallRead()
+        XCTAssertFalse(self.coordinator.shouldWeReadMoreDataFromNetwork())
+        self.coordinator.didReceiveRequestEnd()
+            .assertNothing()
+            .assertDoNotCallRead()
+
+        self.coordinator.didOpenTargetFile(self.fakeFileHandle)
+            .assertStartWriting()
+            .assertDoNotCallRead()
+        XCTAssertEqual(self.byteX, self.coordinator.pullNextChunkToWrite().1)
+        XCTAssertFalse(self.coordinator.shouldWeReadMoreDataFromNetwork())
+        self.coordinator.didFinishWritingOneChunkToFile()
+            .assertCallRead()
+            .assertDiscardResources({ fileHandle, error in
+                XCTAssertNotNil(fileHandle)
+                XCTAssertNil(error)
+            })
+    }
+
+    func testReceiveWholeRequestBeforeFileOpensEmptyFile() {
+        XCTAssertTrue(self.coordinator.shouldWeReadMoreDataFromNetwork())
+        self.coordinator.didReceiveRequestBegin(targetPath: "/")
+            .assertDoNotCallRead()
+            .assertOpenFile({ XCTAssertEqual("/", $0) })
+
+        XCTAssertFalse(self.coordinator.shouldWeReadMoreDataFromNetwork())
+        self.coordinator.didReceiveRequestEnd()
+            .assertNothing()
+            .assertDoNotCallRead()
+
+        XCTAssertFalse(self.coordinator.shouldWeReadMoreDataFromNetwork())
+        self.coordinator.didOpenTargetFile(self.fakeFileHandle)
+            .assertCallRead()
+            .assertDiscardResources({ fileHandle, error in
+                XCTAssertNotNil(fileHandle)
+                XCTAssertNil(error)
+            })
+    }
+
+    func testRequestEndWhilstWriting() {
+        self.moveToBodyStreamingState()
+
+        XCTAssertTrue(self.coordinator.shouldWeReadMoreDataFromNetwork())
+        self.coordinator.didReceiveRequestBodyBytes(self.byteX)
+            .assertStartWriting()
+            .assertDoNotCallRead()
+
+        XCTAssertFalse(self.coordinator.shouldWeReadMoreDataFromNetwork())
+        self.coordinator.didReceiveRequestEnd()
+            .assertNothing()
+            .assertDoNotCallRead()
+
+        XCTAssertEqual(self.byteX, self.coordinator.pullNextChunkToWrite().1)
+        XCTAssertFalse(self.coordinator.shouldWeReadMoreDataFromNetwork())
+        self.coordinator.didFinishWritingOneChunkToFile()
+            .assertDiscardResources({ fileHandle, error in
+                XCTAssertNotNil(fileHandle)
+                XCTAssertNil(error)
+            })
+
+        XCTAssertTrue(self.coordinator.shouldWeReadMoreDataFromNetwork())
+    }
+
+    func testRequestEndWhilstWritingBufferedStuff() {
+        self.moveToBodyStreamingState()
+
+        // Let's buffer 3 chunks
+        XCTAssertTrue(self.coordinator.shouldWeReadMoreDataFromNetwork())
+        self.coordinator.didReceiveRequestBodyBytes(self.byteX)
+            .assertStartWriting()
+            .assertDoNotCallRead()
+        XCTAssertFalse(self.coordinator.shouldWeReadMoreDataFromNetwork())
+        self.coordinator.didReceiveRequestBodyBytes(self.byteY)
+            .assertNothing()
+            .assertDoNotCallRead()
+        XCTAssertFalse(self.coordinator.shouldWeReadMoreDataFromNetwork())
+        self.coordinator.didReceiveRequestBodyBytes(self.byteX)
+            .assertNothing()
+            .assertDoNotCallRead()
+
+        // And an end
+        XCTAssertFalse(self.coordinator.shouldWeReadMoreDataFromNetwork())
+        self.coordinator.didReceiveRequestEnd()
+            .assertNothing()
+            .assertDoNotCallRead()
+
+        XCTAssertEqual(self.byteX, self.coordinator.pullNextChunkToWrite().1)
+        XCTAssertFalse(self.coordinator.shouldWeReadMoreDataFromNetwork())
+        self.coordinator.didFinishWritingOneChunkToFile()
+            .assertStartWriting()
+            .assertDoNotCallRead()
+
+        XCTAssertEqual(self.byteY, self.coordinator.pullNextChunkToWrite().1)
+        XCTAssertFalse(self.coordinator.shouldWeReadMoreDataFromNetwork())
+        self.coordinator.didFinishWritingOneChunkToFile()
+            .assertStartWriting()
+            .assertDoNotCallRead()
+
+        XCTAssertEqual(self.byteX, self.coordinator.pullNextChunkToWrite().1)
+        XCTAssertFalse(self.coordinator.shouldWeReadMoreDataFromNetwork())
+        self.coordinator.didFinishWritingOneChunkToFile()
+            .assertDiscardResources({ fileHandle, error in
+                XCTAssertNotNil(fileHandle)
+                XCTAssertNil(error)
+            })
+            .assertCallRead()
+
+        XCTAssertTrue(self.coordinator.shouldWeReadMoreDataFromNetwork())
+    }
+
+    func testMiddleIsNotAFinalState() {
+        self.moveToBodyStreamingState()
+
+        XCTAssertFalse(self.coordinator.inFinalState)
+
+        self.moveFromBodyStreamingToEnd(expectError: false)
+    }
+}
+
+extension StateMachineTest {
+    override func setUp() {
+        XCTAssertNil(self.coordinator)
+        self.coordinator = FileIOCoordinatorState()
+    }
+
+    override func tearDown() {
+        XCTAssertNotNil(self.coordinator)
+        XCTAssert(self.coordinator.inFinalState)
+        self.coordinator = nil
+    }
+
+    func moveToBodyStreamingState(file: StaticString = #file, line: UInt = #line) {
+        XCTAssertTrue(self.coordinator.shouldWeReadMoreDataFromNetwork(), file: file, line: line)
+        self.coordinator.didReceiveRequestBegin(targetPath: "/")
+            .assertOpenFile({ XCTAssertEqual("/", $0) }, file: file, line: line)
+            .assertDoNotCallRead(file: file, line: line)
+        XCTAssertFalse(self.coordinator.shouldWeReadMoreDataFromNetwork())
+        self.coordinator.didOpenTargetFile(self.fakeFileHandle)
+            .assertNothing(file: file, line: line)
+            .assertCallRead(file: file, line: line)
+        XCTAssertTrue(self.coordinator.shouldWeReadMoreDataFromNetwork())
+    }
+
+    func moveFromBodyStreamingToEnd(expectError: Bool, file: StaticString = #file, line: UInt = #line) {
+        if expectError {
+            XCTAssertFalse(self.coordinator.shouldWeReadMoreDataFromNetwork(), file: file, line: line)
+            self.coordinator.didReceiveRequestEnd()
+                .assertNothing(file: file, line: line)
+                .assertDoNotCallRead()
+        } else {
+            XCTAssertTrue(self.coordinator.shouldWeReadMoreDataFromNetwork(), file: file, line: line)
+            self.coordinator.didReceiveRequestEnd()
+                .assertDiscardResources({ fileHandle, error in
+                    XCTAssertNotNil(fileHandle, file: file, line: line)
+                    XCTAssertNil(error, file: file, line: line)
+                }, file: file, line: line)
+                .assertDoNotCallRead(file: file, line: line) // We haven't held a read...
+        }
+    }
+}
+
+extension StateMachineTest {
+    var byteX: ByteBuffer {
+        var buffer = ByteBufferAllocator().buffer(capacity: 1)
+        buffer.writeString("X")
+        return buffer
+    }
+
+    var byteY: ByteBuffer {
+        var buffer = ByteBufferAllocator().buffer(capacity: 1)
+        buffer.writeString("Y")
+        return buffer
+    }
+
+    var fakeFileHandle: NIOFileHandle {
+        let handle = NIOFileHandle(descriptor: .max)
+        _ = try! handle.takeDescriptorOwnership() // we're not actually using this file handle
+        return handle
+    }
+
+    struct DummyError: Error {}
+}
+
+extension FileIOCoordinatorState.Action {
+    @discardableResult
+    func assertOpenFile(_ check: (String) throws -> Void,
+                        file: StaticString = #file,
+                        line: UInt = #line) -> Self {
+        if case .openFile(let path) = self.main {
+            XCTAssertNoThrow(try check(path))
+        } else {
+            XCTFail("action \(self) not \(#function)", file: file, line: line)
+        }
+        return self
+    }
+
+    @discardableResult
+    func assertDiscardResources(_ check: (NIOFileHandle?, Error?) throws -> Void,
+                                file: StaticString = #file,
+                                line: UInt = #line) -> Self {
+        if case .processingCompletedDiscardResources(let fileHandle, let error) = self.main {
+            XCTAssertNoThrow(try check(fileHandle, error))
+        } else {
+            XCTFail("action \(self) not \(#function)", file: file, line: line)
+        }
+        return self
+    }
+
+    @discardableResult
+    func assertCloseFile(_ check: (NIOFileHandle) throws -> Void,
+                         file: StaticString = #file,
+                         line: UInt = #line) -> Self {
+        if case .closeFile(let fileHandle) = self.main {
+            XCTAssertNoThrow(try check(fileHandle))
+        } else {
+            XCTFail("action \(self) not \(#function)", file: file, line: line)
+        }
+        return self
+    }
+
+    @discardableResult
+    func assertNothing(file: StaticString = #file,
+                       line: UInt = #line) -> Self {
+        if case .nothingWeAreWaiting = self.main {
+            () // cool
+        } else {
+            XCTFail("action \(self) not \(#function)", file: file, line: line)
+        }
+        return self
+    }
+
+    @discardableResult
+    func assertStartWriting(file: StaticString = #file,
+                            line: UInt = #line) -> Self {
+        if case .startWritingToTargetFile = self.main {
+            () // cool
+        } else {
+            XCTFail("action \(self) not \(#function)", file: file, line: line)
+        }
+        return self
+    }
+
+    @discardableResult
+    func assertCallRead(file: StaticString = #file,
+                       line: UInt = #line) -> Self {
+        XCTAssertTrue(self.callRead, file: file, line: line)
+        return self
+    }
+
+    @discardableResult
+    func assertDoNotCallRead(file: StaticString = #file,
+                       line: UInt = #line) -> Self {
+        XCTAssertFalse(self.callRead, "callRead unexpectedly true", file: file, line: line)
+        return self
+    }
+
+
+}


### PR DESCRIPTION
The BackpressureChannelToFileIO demo became quite popular but I haven't
seen people writing tests. Also, the example actually had one bug
(receiving an error whilst writing) which would lead to followon bugs.

Therefore, I thought we should demonstrate 100% test coverage of the
state machine (whilst fixing the bug).