### PR TITLE
BackpressureFileIO: accidental logLevel = .trace

### DIFF
--- a/backpressure-file-io-channel/Sources/BackpressureChannelToFileIODemo/main.swift
+++ b/backpressure-file-io-channel/Sources/BackpressureChannelToFileIODemo/main.swift
@@ -30,7 +30,7 @@ defer {
 let fileIO = NonBlockingFileIO(threadPool: threadPool)
 
 var logger = Logger(label: "BackpressureChannelToFileIO")
-logger.logLevel = .trace
+logger.logLevel = .info
 let server = try ServerBootstrap(group: group)
         .serverChannelOption(ChannelOptions.socket(.init(SOL_SOCKET), .init(SO_REUSEADDR)), value: 1)
         .childChannelInitializer { [logger] channel in


### PR DESCRIPTION
I accidentally committed logLevel = .trace which makes everything go
terribly slow :|.