### PR TITLE
Missing .gitignore files; minor cleanup

### DIFF
--- a/UniversalBootstrapDemo/.gitignore
+++ b/UniversalBootstrapDemo/.gitignore
@@ -1,0 +1,1 @@
+*.xcodeproj

--- a/UniversalBootstrapDemo/Sources/UniversalBootstrapDemo/ExampleHTTPLibrary.swift
+++ b/UniversalBootstrapDemo/Sources/UniversalBootstrapDemo/ExampleHTTPLibrary.swift
@@ -53,11 +53,10 @@ public class ExampleHTTPLibrary {
         guard let url = URL(string: urlString),
               let hostname = url.host,
               let scheme = url.scheme?.lowercased(),
-              ["http", "https"].contains(scheme.lowercased()) else {
+              ["http", "https"].contains(scheme) else {
             throw UnsupportedURLError(url: urlString)
         }
-        let uri = url.path
-        let useTLS = url.scheme?.lowercased() == "https" ? true : false
+        let useTLS = scheme == "https"
         let connection = try groupManager.makeBootstrap(hostname: hostname, useTLS: useTLS)
                 .channelInitializer { channel in
                     channel.pipeline.addHTTPClientHandlers().flatMap {
@@ -73,7 +72,7 @@ public class ExampleHTTPLibrary {
         print("# HTTP response body")
         let reqHead = HTTPClientRequestPart.head(.init(version: .init(major: 1, minor: 1),
                                                        method: .GET,
-                                                       uri: uri,
+                                                       uri: url.path,
                                                        headers: ["host": hostname]))
         connection.write(reqHead, promise: nil)
         try connection.writeAndFlush(HTTPClientRequestPart.end(nil)).wait()

--- a/backpressure-file-io-channel/.gitignore
+++ b/backpressure-file-io-channel/.gitignore
@@ -1,0 +1,1 @@
+*.xcodeproj

--- a/connect-proxy/.gitignore
+++ b/connect-proxy/.gitignore
@@ -1,0 +1,1 @@
+*.xcodeproj


### PR DESCRIPTION
Missing .gitignore files; minor cleanup

### Motivation:

Certain subprojects still miss their own .gitignore files with at least *.xcodeproj excluded while others do have them.

Also in the UniversalBootstrapDemo subproject: while reading the sources I noticed some minor redundancies and removed them. This should not affect the logic of the program.

### Modifications:

Added the missing .gitignore files under 3 subprojects. The root .gitignore already handles other typical "ignorables".

### Result:

XCode project files can now be created under all projects and automatically ignored by git.