### PR TITLE
Update callsite for bootstrap.withBoundSocket(descriptor:)

### DIFF
--- a/UniversalBootstrapDemo/Package.swift
+++ b/UniversalBootstrapDemo/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "UniversalBootstrapDemo",
     dependencies: [
-        .package(url: "https://github.com/apple/swift-nio.git", from: "2.16.1"),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.20.0"),
         .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.7.1"),
         .package(url: "https://github.com/apple/swift-nio-transport-services.git", from: "1.5.1"),
         .package(url: "https://github.com/apple/swift-argument-parser.git", .upToNextMinor(from: "0.0.5"))

--- a/nio-launchd/Sources/nio-launchd/Server.swift
+++ b/nio-launchd/Sources/nio-launchd/Server.swift
@@ -73,7 +73,7 @@ struct Server: ParsableCommand {
             .childChannelOption(ChannelOptions.recvAllocator, value: AdaptiveRecvByteBufferAllocator())
 
         // Bootstrap using the socket we got from launchd.
-        let server = try bootstrap.withBoundSocket(descriptor: fd).wait()
+        let server = try bootstrap.withBoundSocket(fd).wait()
         try server.closeFuture.wait()
     }
 }


### PR DESCRIPTION
Motivation:
Felt the example projects should reflect latest API design and wanted to fix the deprecation warning

Modifications:
Removed the argument label `descriptor:` from the call site as suggested by the quick fix in Xcode

Result:
No changes in behavior are expected.