### PR TITLE
Fix circular references in GlueHandler

### DIFF
--- a/connect-proxy/Sources/ConnectProxy/GlueHandler.swift
+++ b/connect-proxy/Sources/ConnectProxy/GlueHandler.swift
@@ -16,7 +16,7 @@ import NIO
 
 
 final class GlueHandler {
-    private var partner: GlueHandler?
+    private weak var partner: GlueHandler?
 
     private var context: ChannelHandlerContext?
 


### PR DESCRIPTION
Fix circular references in GlueHandler

### Motivation:

GlueHandler makes circular references to partner. But they strongly reference each other, causing memory leak problems.

### Modifications:

Fix GlueHandler to weakly reference its partner

### Result:

Fix circular reference issues so no memory leaks
