### PR TITLE
Improve proxy server pipeline readability

### DIFF
--- a/connect-proxy/Sources/ConnectProxy/main.swift
+++ b/connect-proxy/Sources/ConnectProxy/main.swift
@@ -22,11 +22,9 @@ let bootstrap = ServerBootstrap(group: group)
     .serverChannelOption(ChannelOptions.socket(SOL_SOCKET, SO_REUSEADDR), value: 1)
     .childChannelOption(ChannelOptions.socket(SOL_SOCKET, SO_REUSEADDR), value: 1)
     .childChannelInitializer { channel in
-        channel.pipeline.addHandler(ByteToMessageHandler(HTTPRequestDecoder(leftOverBytesStrategy: .forwardBytes))).flatMap {
-            channel.pipeline.addHandler(HTTPResponseEncoder()).flatMap {
-                channel.pipeline.addHandler(ConnectHandler(logger: Logger(label: "com.apple.nio-connect-proxy.ConnectHandler")))
-            }
-        }
+        channel.pipeline.addHandler(ByteToMessageHandler(HTTPRequestDecoder(leftOverBytesStrategy: .forwardBytes)))
+            .flatMap { channel.pipeline.addHandler(HTTPResponseEncoder()) }
+            .flatMap { channel.pipeline.addHandler(ConnectHandler(logger: Logger(label: "com.apple.nio-connect-proxy.ConnectHandler"))) }
     }
 
 bootstrap.bind(to: try! SocketAddress(ipAddress: "127.0.0.1", port: 8080)).whenComplete { result in


### PR DESCRIPTION
Improve proxy server pipeline readability

### Motivation:

Unnecessary indentation was used in the proxy server pipeline configuration code.

### Modifications:

Use flatMap as a chaining rather than nesting

### Result:

Indentation was removed, so readability is improved
