### PR TITLE
Require Swift 5.4

### DIFF
--- a/TLSify/Package.swift
+++ b/TLSify/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.1
+// swift-tools-version:5.4
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/UniversalBootstrapDemo/Package.swift
+++ b/UniversalBootstrapDemo/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.1
+// swift-tools-version:5.4
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/backpressure-file-io-channel/Package.swift
+++ b/backpressure-file-io-channel/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.1
+// swift-tools-version:5.4
 import PackageDescription
 
 let package = Package(

--- a/connect-proxy/Package.swift
+++ b/connect-proxy/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.0
+// swift-tools-version:5.4
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the SwiftNIO open source project

--- a/http2-client/Package.swift
+++ b/http2-client/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.0
+// swift-tools-version:5.4
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/http2-server/Package.swift
+++ b/http2-server/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.1
+// swift-tools-version:5.4
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the SwiftNIO open source project

--- a/json-rpc/Package.swift
+++ b/json-rpc/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.0
+// swift-tools-version:5.4
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/nio-launchd/Package.swift
+++ b/nio-launchd/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.1
+// swift-tools-version:5.4
 import PackageDescription
 
 let package = Package(


### PR DESCRIPTION
Since we only support Swift 5.4 and later into the future, we should require it in all examples.