### PR TITLE
TLSify: allow sending ALPN

### DIFF
--- a/TLSify/Sources/TLSify/main.swift
+++ b/TLSify/Sources/TLSify/main.swift
@@ -38,6 +38,9 @@ struct TLSifyCommand: ParsableCommand {
     @Option(name: .long, help: "TLS certificate verfication: full (default)/no-hostname/none.")
     var tlsCertificateValidation: String = "full"
 
+    @Option(help: "The ALPN protocols to send.")
+    var alpn: [String] = []
+
     func run() throws {
         var tlsConfig = TLSConfiguration.makeClientConfiguration()
         switch self.tlsCertificateValidation {
@@ -48,6 +51,7 @@ struct TLSifyCommand: ParsableCommand {
         default:
             tlsConfig.certificateVerification = .fullVerification
         }
+        tlsConfig.applicationProtocols = self.alpn
         let sslContext = try NIOSSLContext(configuration: tlsConfig)
         MultiThreadedEventLoopGroup.withCurrentThreadAsEventLoop { el in
             ServerBootstrap(group: el)


### PR DESCRIPTION
### Motivation:

ALPN is great, especially when using `TLSify` to analyse `curl` H2 traffic in plaintext using

```
TLSify --alpn h2 8080 myhost.com 443
```

```
curl --http2-prior-knowledge -H 'host:myhost.com' http://localhost:8080/
```

### Modifications:

- add a `--alpn` option that can be used to pass ALPN protocol(s).

### Result:

More features.