### PR TITLE
Update minimum Swift version to be 5.5

### DIFF
--- a/TLSify/Package.swift
+++ b/TLSify/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.4
+// swift-tools-version:5.5
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -9,7 +9,7 @@ let package = Package(
         .executable(name: "TLSify", targets: ["TLSify"])
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-nio.git", from: "2.17.0"),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.42.0"),
         .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.14.0"),
         .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),

--- a/UniversalBootstrapDemo/Package.swift
+++ b/UniversalBootstrapDemo/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.4
+// swift-tools-version:5.5
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "UniversalBootstrapDemo",
     dependencies: [
-        .package(url: "https://github.com/apple/swift-nio.git", from: "2.33.0"),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.42.0"),
         .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.16.1"),
         .package(url: "https://github.com/apple/swift-nio-transport-services.git", from: "1.11.3"),
         .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.0.1")

--- a/UniversalBootstrapDemo/Sources/UniversalBootstrapDemo/EventLoopGroupManager.swift
+++ b/UniversalBootstrapDemo/Sources/UniversalBootstrapDemo/EventLoopGroupManager.swift
@@ -33,7 +33,7 @@ import NIOConcurrencyHelpers
 /// knowing the concrete `EventLoopGroup` type (it may be `SelectableEventLoop` which is an internal `NIO` types).
 /// `EventLoopGroupManager` should support all those use cases with a simple API.
 public class EventLoopGroupManager: @unchecked Sendable {
-    private let lock = Lock()
+    private let lock = NIOLock()
     private var group: Optional<EventLoopGroup>
     private let provider: Provider
     private var sslContext = try! NIOSSLContext(configuration: .makeClientConfiguration())

--- a/UniversalBootstrapDemo/Sources/UniversalBootstrapDemo/ExampleHTTPLibrary.swift
+++ b/UniversalBootstrapDemo/Sources/UniversalBootstrapDemo/ExampleHTTPLibrary.swift
@@ -20,7 +20,7 @@ public struct UnsupportedURLError: Error {
     var url: String
 }
 
-public class ExampleHTTPLibrary: Sendable {
+public final class ExampleHTTPLibrary: Sendable {
     let groupManager: EventLoopGroupManager
 
     public init(groupProvider provider: EventLoopGroupManager.Provider) {

--- a/backpressure-file-io-channel/Package.swift
+++ b/backpressure-file-io-channel/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.4
+// swift-tools-version:5.5
 import PackageDescription
 
 let package = Package(
@@ -7,7 +7,7 @@ let package = Package(
         .macOS(.v10_15), .iOS(.v13), .tvOS(.v13)
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-nio.git", from: "2.16.1"),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.42.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.1.0"),
     ],
     targets: [

--- a/connect-proxy/Package.swift
+++ b/connect-proxy/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.4
+// swift-tools-version:5.5
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the SwiftNIO open source project
@@ -21,7 +21,7 @@ let package = Package(
         .executable(name: "ConnectProxy", targets: ["ConnectProxy"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-nio.git", from: "2.0.0"),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.42.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
     ],
     targets: [

--- a/http2-client/Package.swift
+++ b/http2-client/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.4
+// swift-tools-version:5.5
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -7,7 +7,7 @@ let package = Package(
     name: "http2-client",
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(url: "https://github.com/apple/swift-nio", from: "2.13.0"),
+        .package(url: "https://github.com/apple/swift-nio", from: "2.42.0"),
         .package(url: "https://github.com/apple/swift-nio-ssl", from: "2.6.0"),
         .package(url: "https://github.com/apple/swift-nio-http2", from: "1.9.0"),
         .package(url: "https://github.com/apple/swift-nio-extras", from: "1.0.0"),

--- a/http2-server/Package.swift
+++ b/http2-server/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.4
+// swift-tools-version:5.5
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the SwiftNIO open source project
@@ -18,7 +18,7 @@ import PackageDescription
 let package = Package(
     name: "http2-server",
     dependencies: [
-        .package(url: "https://github.com/apple/swift-nio.git", from: "2.13.0"),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.42.0"),
         .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.6.0"),
         .package(url: "https://github.com/apple/swift-nio-http2.git", from: "1.9.0"),
     ],

--- a/json-rpc/Package.swift
+++ b/json-rpc/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.4
+// swift-tools-version:5.5
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -12,7 +12,7 @@ let package = Package(
         .executable(name: "LightsdDemo", targets: ["LightsdDemo"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-nio", from: "2.0.0"),
+        .package(url: "https://github.com/apple/swift-nio", from: "2.42.0"),
         .package(url: "https://github.com/apple/swift-nio-extras", from: "1.0.0"),
     ],
     targets: [

--- a/json-rpc/Sources/JsonRpc/Client.swift
+++ b/json-rpc/Sources/JsonRpc/Client.swift
@@ -3,7 +3,7 @@ import NIO
 import NIOConcurrencyHelpers
 
 public final class TCPClient: @unchecked Sendable {
-    private let lock = Lock()
+    private let lock = NIOLock()
     private var state = State.initializing
     public let group: MultiThreadedEventLoopGroup
     public let config: Config

--- a/json-rpc/Sources/JsonRpc/Server.swift
+++ b/json-rpc/Sources/JsonRpc/Server.swift
@@ -8,7 +8,7 @@ public final class TCPServer: @unchecked Sendable {
     private var channel: Channel?
     private let closure: RPCClosure
     private var state = State.initializing
-    private let lock = Lock()
+    private let lock = NIOLock()
 
     public init(group: MultiThreadedEventLoopGroup, config: Config = Config(), closure: @escaping RPCClosure) {
         self.group = group

--- a/nio-launchd/Package.swift
+++ b/nio-launchd/Package.swift
@@ -1,11 +1,11 @@
-// swift-tools-version:5.4
+// swift-tools-version:5.5
 import PackageDescription
 
 let package = Package(
     name: "nio-launchd",
     dependencies: [
-        .package(url: "https://github.com/apple/swift-argument-parser.git", from: "0.0.0"),
-        .package(url: "https://github.com/apple/swift-nio.git", from: "2.14.0"),
+        .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.0.0"),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.42.0"),
     ],
     targets: [
         .executableTarget(


### PR DESCRIPTION
Motivation:

NIO periodically drops old Swift versions. It has just dropped support for 5.4 so the examples should use 5.5 at a minimum.

Modifications:

- Update the tools version for each example
- Fix warnings

Result:

Minimum Swift version is 5.5. Fewer warnings.