### PR TITLE
Rewrite NIO imports

### DIFF
--- a/NIOSMTP/NIOSMTP/AppDelegate.swift
+++ b/NIOSMTP/NIOSMTP/AppDelegate.swift
@@ -13,8 +13,6 @@
 //===----------------------------------------------------------------------===//
 
 import UIKit
-import NIO
-import NIOTransportServices
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {

--- a/NIOSMTP/NIOSMTP/PrintEverythingHandler.swift
+++ b/NIOSMTP/NIOSMTP/PrintEverythingHandler.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import NIO
+import NIOCore
 import NIOTransportServices
 import Foundation
 

--- a/NIOSMTP/NIOSMTP/SMTPRequestEncoder.swift
+++ b/NIOSMTP/NIOSMTP/SMTPRequestEncoder.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import NIO
+import NIOCore
 import NIOFoundationCompat
 import Foundation
 

--- a/NIOSMTP/NIOSMTP/SMTPResponseDecoder.swift
+++ b/NIOSMTP/NIOSMTP/SMTPResponseDecoder.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import NIO
+import NIOCore
 
 /// `SMTPResponseDecoder` decodes exactly one SMTP response from already newline-framed input messages.
 ///

--- a/NIOSMTP/NIOSMTP/SendEmailHandler.swift
+++ b/NIOSMTP/NIOSMTP/SendEmailHandler.swift
@@ -12,11 +12,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-import NIO
+import NIOCore
 import NIOSSL
 import UIKit
 
-private let sslContext = try! NIOSSLContext(configuration: TLSConfiguration.forClient())
+private let sslContext = try! NIOSSLContext(configuration: TLSConfiguration.makeClientConfiguration())
 
 final class SendEmailHandler: ChannelInboundHandler {
     typealias InboundIn = SMTPResponse

--- a/NIOSMTP/NIOSMTP/ViewController.swift
+++ b/NIOSMTP/NIOSMTP/ViewController.swift
@@ -13,8 +13,9 @@
 //===----------------------------------------------------------------------===//
 
 import UIKit
-import NIO
+import NIOCore
 import NIOExtras
+import NIOPosix
 import NIOTransportServices
 import NIOTLS
 import NIOSSL
@@ -127,7 +128,7 @@ func makeNIOSMTPHandlers(communicationHandler: @escaping (String) -> Void,
     ]
 }
 
-private let sslContext = try! NIOSSLContext(configuration: TLSConfiguration.forClient())
+private let sslContext = try! NIOSSLContext(configuration: TLSConfiguration.makeClientConfiguration())
 
 func configureBootstrap(group: EventLoopGroup,
                         email: Email,

--- a/TLSify/Package.swift
+++ b/TLSify/Package.swift
@@ -22,13 +22,15 @@ let package = Package(
             dependencies: [
                 "TLSifyLib",
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
-                .product(name: "NIO", package: "swift-nio"),
+                .product(name: "NIOCore", package: "swift-nio"),
+                .product(name: "NIOPosix", package: "swift-nio"),
                 .product(name: "Logging", package: "swift-log"),
             ]),
         .target(
             name: "TLSifyLib",
             dependencies: [
-                .product(name: "NIO", package: "swift-nio"),
+                .product(name: "NIOCore", package: "swift-nio"),
+                .product(name: "NIOPosix", package: "swift-nio"),
                 .product(name: "NIOSSL", package: "swift-nio-ssl"),
                 .product(name: "Logging", package: "swift-log"),
             ]),

--- a/TLSify/Sources/TLSify/main.swift
+++ b/TLSify/Sources/TLSify/main.swift
@@ -13,7 +13,8 @@
 //===----------------------------------------------------------------------===//
 
 import ArgumentParser
-import NIO
+import NIOCore
+import NIOPosix
 import NIOSSL
 import Logging
 
@@ -31,7 +32,7 @@ struct TLSifyCommand: ParsableCommand {
 
     @Argument(help: "The host to connect to.")
     var connectHost: String
-    
+
     @Argument(help: "The port to connect to.")
     var connectPort: Int
 

--- a/TLSify/Sources/TLSifyLib/CloseOnErrorHandler.swift
+++ b/TLSify/Sources/TLSifyLib/CloseOnErrorHandler.swift
@@ -12,18 +12,18 @@
 //
 //===----------------------------------------------------------------------===//
 
-import NIO
+import NIOCore
 import Logging
 
 final class CloseOnErrorHandler: ChannelInboundHandler, Sendable {
     typealias InboundIn = Never
-    
+
     private let logger: Logger
-    
+
     init(logger: Logger) {
         self.logger = logger
     }
-    
+
     func errorCaught(context: ChannelHandlerContext, error: Error) {
         self.logger.info("unhandled error \(error), closing \(context.channel)")
         context.close(promise: nil)

--- a/TLSify/Sources/TLSifyLib/GlueHandler.swift
+++ b/TLSify/Sources/TLSifyLib/GlueHandler.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import NIO
+import NIOCore
 import Logging
 
 final class GlueHandler {
@@ -21,7 +21,7 @@ final class GlueHandler {
     var context: Optional<ChannelHandlerContext> = nil
     var partner: Optional<GlueHandler> = nil
     private var pendingRead = false
-    
+
     internal init(logger: Logger) {
         self.logger = logger
     }
@@ -59,15 +59,15 @@ extension GlueHandler {
 extension GlueHandler: ChannelDuplexHandler {
     typealias InboundIn = ByteBuffer
     typealias InboundOut = ByteBuffer
-    
+
     typealias OutboundIn = ByteBuffer
     typealias OutboundOut = ByteBuffer
-    
+
     func handlerAdded(context: ChannelHandlerContext) {
         self.logger[metadataKey: "channel"] = "\(context.channel)"
         self.context = context
     }
-    
+
     func handlerRemoved(context: ChannelHandlerContext) {
         self.context = nil
         self.partner = nil

--- a/UniversalBootstrapDemo/Package.swift
+++ b/UniversalBootstrapDemo/Package.swift
@@ -15,7 +15,8 @@ let package = Package(
         .executableTarget(
             name: "UniversalBootstrapDemo",
             dependencies: [
-                .product(name: "NIO", package: "swift-nio"),
+                .product(name: "NIOCore", package: "swift-nio"),
+                .product(name: "NIOPosix", package: "swift-nio"),
                 .product(name: "NIOSSL", package: "swift-nio-ssl"),
                 .product(name: "NIOTransportServices", package: "swift-nio-transport-services"),
                 .product(name: "NIOHTTP1", package: "swift-nio"),

--- a/UniversalBootstrapDemo/Sources/UniversalBootstrapDemo/EventLoopGroupManager.swift
+++ b/UniversalBootstrapDemo/Sources/UniversalBootstrapDemo/EventLoopGroupManager.swift
@@ -12,7 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-import NIO
+import NIOCore
+import NIOPosix
 import NIOTransportServices
 import NIOSSL
 import NIOConcurrencyHelpers

--- a/UniversalBootstrapDemo/Sources/UniversalBootstrapDemo/ExampleHTTPLibrary.swift
+++ b/UniversalBootstrapDemo/Sources/UniversalBootstrapDemo/ExampleHTTPLibrary.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import NIO
+import NIOCore
 import NIOHTTP1
 import Foundation
 

--- a/UniversalBootstrapDemo/Sources/UniversalBootstrapDemo/main.swift
+++ b/UniversalBootstrapDemo/Sources/UniversalBootstrapDemo/main.swift
@@ -14,7 +14,8 @@
 
 import ArgumentParser
 import Foundation
-import NIO
+import NIOCore
+import NIOPosix
 import NIOTransportServices
 
 struct UniversalBootstrapDemo: ParsableCommand {

--- a/backpressure-file-io-channel/Package.swift
+++ b/backpressure-file-io-channel/Package.swift
@@ -14,7 +14,8 @@ let package = Package(
         .target(
             name: "BackpressureChannelToFileIO",
             dependencies: [
-                .product(name: "NIO", package: "swift-nio"),
+                .product(name: "NIOCore", package: "swift-nio"),
+                .product(name: "NIOPosix", package: "swift-nio"),
                 .product(name: "NIOHTTP1", package: "swift-nio"),
                 .product(name: "Logging", package: "swift-log"),
             ]),
@@ -22,14 +23,16 @@ let package = Package(
             name: "BackpressureChannelToFileIODemo",
             dependencies: [
                 "BackpressureChannelToFileIO",
-                .product(name: "NIO", package: "swift-nio"),
+                .product(name: "NIOCore", package: "swift-nio"),
+                .product(name: "NIOPosix", package: "swift-nio"),
                 .product(name: "Logging", package: "swift-log"),
             ]),
         .testTarget(
             name: "BackpressureChannelToFileIOTests",
             dependencies: [
                 "BackpressureChannelToFileIO",
-                .product(name: "NIO", package: "swift-nio"),
+                .product(name: "NIOCore", package: "swift-nio"),
+                .product(name: "NIOPosix", package: "swift-nio"),
             ]),
     ]
 )

--- a/backpressure-file-io-channel/Sources/BackpressureChannelToFileIO/FileIOChannelWriteCoordinator.swift
+++ b/backpressure-file-io-channel/Sources/BackpressureChannelToFileIO/FileIOChannelWriteCoordinator.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import NIO
+import NIOCore
 
 internal struct FileIOCoordinatorState {
     /// The actions for the driver of the state machine to perform.

--- a/backpressure-file-io-channel/Sources/BackpressureChannelToFileIO/SaveEverythingHTTPServer.swift
+++ b/backpressure-file-io-channel/Sources/BackpressureChannelToFileIO/SaveEverythingHTTPServer.swift
@@ -12,7 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-import NIO
+import NIOCore
+import NIOPosix
 import NIOHTTP1
 import Logging
 
@@ -36,7 +37,7 @@ public final class SaveEverythingHTTPServer {
         }
         self.uploadDirectory = uploadDirectory
     }
-    
+
     deinit {
         assert(self.state.inFinalState, "illegal state on handler removal: \(self.state)")
     }

--- a/backpressure-file-io-channel/Sources/BackpressureChannelToFileIODemo/main.swift
+++ b/backpressure-file-io-channel/Sources/BackpressureChannelToFileIODemo/main.swift
@@ -12,7 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-import NIO
+import NIOCore
+import NIOPosix
 import Logging
 import BackpressureChannelToFileIO
 

--- a/backpressure-file-io-channel/Tests/BackpressureChannelToFileIOTests/StateMachineTest.swift
+++ b/backpressure-file-io-channel/Tests/BackpressureChannelToFileIOTests/StateMachineTest.swift
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import XCTest
-import NIO
+import NIOCore
 @testable import BackpressureChannelToFileIO
 
 final class StateMachineTest: XCTestCase {

--- a/connect-proxy/Package.swift
+++ b/connect-proxy/Package.swift
@@ -28,7 +28,8 @@ let package = Package(
         .executableTarget(
             name: "ConnectProxy",
             dependencies: [
-                .product(name: "NIO", package: "swift-nio"),
+                .product(name: "NIOCore", package: "swift-nio"),
+                .product(name: "NIOPosix", package: "swift-nio"),
                 .product(name: "NIOHTTP1", package: "swift-nio"),
                 .product(name: "Logging", package: "swift-log"),
             ]),

--- a/connect-proxy/Sources/ConnectProxy/ConnectHandler.swift
+++ b/connect-proxy/Sources/ConnectProxy/ConnectHandler.swift
@@ -12,7 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-import NIO
+import NIOCore
+import NIOPosix
 import NIOHTTP1
 import Logging
 

--- a/connect-proxy/Sources/ConnectProxy/GlueHandler.swift
+++ b/connect-proxy/Sources/ConnectProxy/GlueHandler.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import NIO
+import NIOCore
 
 final class GlueHandler {
 

--- a/connect-proxy/Sources/ConnectProxy/main.swift
+++ b/connect-proxy/Sources/ConnectProxy/main.swift
@@ -12,7 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-import NIO
+import NIOCore
+import NIOPosix
 import NIOHTTP1
 import Logging
 import Dispatch

--- a/http2-client/Package.swift
+++ b/http2-client/Package.swift
@@ -18,7 +18,8 @@ let package = Package(
         .executableTarget(
             name: "http2-client",
             dependencies: [
-                .product(name: "NIO", package: "swift-nio"),
+                .product(name: "NIOCore", package: "swift-nio"),
+                .product(name: "NIOPosix", package: "swift-nio"),
                 .product(name: "NIOTLS", package: "swift-nio"),
                 .product(name: "NIOSSL", package: "swift-nio-ssl"),
                 .product(name: "NIOHTTP1", package: "swift-nio"),

--- a/http2-client/Sources/http2-client/main.swift
+++ b/http2-client/Sources/http2-client/main.swift
@@ -12,9 +12,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-import NIO
+import NIOCore
 import NIOHTTP1
 import NIOHTTP2
+import NIOPosix
 import NIOTLS
 import NIOSSL
 import Foundation
@@ -118,7 +119,7 @@ final class CollectErrorsAndCloseStreamHandler: ChannelInboundHandler, Sendable 
     typealias InboundIn = Never
 
     private let promise: EventLoopPromise<Void>
-    
+
     init(promise: EventLoopPromise<Void>) {
         self.promise = promise
     }

--- a/http2-server/Package.swift
+++ b/http2-server/Package.swift
@@ -28,7 +28,8 @@ let package = Package(
         .executableTarget(
             name: "http2-server",
             dependencies: [
-                .product(name: "NIO", package: "swift-nio"),
+                .product(name: "NIOCore", package: "swift-nio"),
+                .product(name: "NIOPosix", package: "swift-nio"),
                 .product(name: "NIOSSL", package: "swift-nio-ssl"),
                 .product(name: "NIOHTTP1", package: "swift-nio"),
                 .product(name: "NIOHTTP2", package: "swift-nio-http2"),

--- a/http2-server/Sources/http2-server/main.swift
+++ b/http2-server/Sources/http2-server/main.swift
@@ -12,7 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-import NIO
+import NIOCore
+import NIOPosix
 import NIOSSL
 import NIOHTTP1
 import NIOHTTP2

--- a/json-rpc/Package.swift
+++ b/json-rpc/Package.swift
@@ -19,7 +19,9 @@ let package = Package(
         .target(
             name: "JSONRPC",
             dependencies: [
-                .product(name: "NIO", package: "swift-nio"),
+                .product(name: "NIOCore", package: "swift-nio"),
+                .product(name: "NIOConcurrencyHelpers", package: "swift-nio"),
+                .product(name: "NIOPosix", package: "swift-nio"),
                 .product(name: "NIOFoundationCompat", package: "swift-nio"),
                 .product(name: "NIOExtras", package: "swift-nio-extras"),
             ],
@@ -42,7 +44,9 @@ let package = Package(
         .testTarget(
             name: "JSONRPCTests",
             dependencies: [
-                "JSONRPC"
+                "JSONRPC",
+                .product(name: "NIOCore", package: "swift-nio"),
+                .product(name: "NIOPosix", package: "swift-nio"),
             ],
             path: "Tests/JsonRpcTests"),
     ]

--- a/json-rpc/Sources/ClientExample/main.swift
+++ b/json-rpc/Sources/ClientExample/main.swift
@@ -1,5 +1,6 @@
 import JSONRPC
-import NIO
+import NIOCore
+import NIOPosix
 
 guard CommandLine.arguments.count > 1 else {
     fatalError("invalid arguments")

--- a/json-rpc/Sources/JsonRpc/Client.swift
+++ b/json-rpc/Sources/JsonRpc/Client.swift
@@ -1,6 +1,7 @@
 import Foundation
-import NIO
+import NIOCore
 import NIOConcurrencyHelpers
+import NIOPosix
 
 public final class TCPClient: @unchecked Sendable {
     private let lock = NIOLock()

--- a/json-rpc/Sources/JsonRpc/Codec.swift
+++ b/json-rpc/Sources/JsonRpc/Codec.swift
@@ -1,5 +1,5 @@
 import Foundation
-import NIO
+import NIOCore
 import NIOFoundationCompat
 
 private let maxPayload = 1_000_000 // 1MB

--- a/json-rpc/Sources/JsonRpc/Server.swift
+++ b/json-rpc/Sources/JsonRpc/Server.swift
@@ -1,5 +1,6 @@
 import Foundation
-import NIO
+import NIOCore
+import NIOPosix
 import NIOConcurrencyHelpers
 
 public final class TCPServer: @unchecked Sendable {

--- a/json-rpc/Sources/JsonRpc/Utils.swift
+++ b/json-rpc/Sources/JsonRpc/Utils.swift
@@ -1,5 +1,4 @@
 import Foundation
-import NIO
 
 public enum ResultType<Value, Error> {
     case success(Value)

--- a/json-rpc/Sources/LightsdDemo/main.swift
+++ b/json-rpc/Sources/LightsdDemo/main.swift
@@ -1,5 +1,6 @@
 import JSONRPC
-import NIO
+import NIOCore
+import NIOPosix
 
 struct Lifx {
     let id: String

--- a/json-rpc/Sources/ServerExample/main.swift
+++ b/json-rpc/Sources/ServerExample/main.swift
@@ -1,6 +1,7 @@
 import Dispatch
 import JSONRPC
-import NIO
+import NIOCore
+import NIOPosix
 
 private final class Calculator: Sendable  {
     func handle(method: String, params: RPCObject, callback: (RPCResult) -> Void) {

--- a/json-rpc/Tests/JsonRpcTests/JsonRpcTests.swift
+++ b/json-rpc/Tests/JsonRpcTests/JsonRpcTests.swift
@@ -1,5 +1,6 @@
 @testable import JSONRPC
-import NIO
+import NIOCore
+import NIOPosix
 import XCTest
 
 final class JSONRPCTests: XCTestCase {

--- a/nio-launchd/Package.swift
+++ b/nio-launchd/Package.swift
@@ -11,7 +11,8 @@ let package = Package(
         .executableTarget(
             name: "nio-launchd",
             dependencies: [
-                .product(name: "NIO", package: "swift-nio"),
+                .product(name: "NIOCore", package: "swift-nio"),
+                .product(name: "NIOPosix", package: "swift-nio"),
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
             ]),
     ]

--- a/nio-launchd/Sources/nio-launchd/Client.swift
+++ b/nio-launchd/Sources/nio-launchd/Client.swift
@@ -12,7 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-import NIO
+import NIOCore
+import NIOPosix
 import ArgumentParser
 
 struct Client: ParsableCommand {

--- a/nio-launchd/Sources/nio-launchd/Server.swift
+++ b/nio-launchd/Sources/nio-launchd/Server.swift
@@ -12,7 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-import NIO
+import NIOCore
+import NIOPosix
 import ArgumentParser
 import launch
 

--- a/nio-launchd/Sources/nio-launchd/main.swift
+++ b/nio-launchd/Sources/nio-launchd/main.swift
@@ -13,7 +13,6 @@
 //===----------------------------------------------------------------------===//
 
 import ArgumentParser
-import NIO
 
 struct CLI: ParsableCommand {
     static let configuration = CommandConfiguration(


### PR DESCRIPTION
Motivation:

In NIO 2.32.0 we split the NIO module up. We rewrote the imports
of other NIO packages after that except for this one.

Modifications:

- Update imports
- Fix a couple of deprecation warnings along the way

Result:

Up-to-date imports, fewer warnings.