### PR TITLE
Drop 5.5 support in examples.

### DIFF
--- a/TLSify/Package.swift
+++ b/TLSify/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.5
+// swift-tools-version:5.6
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/UniversalBootstrapDemo/Package.swift
+++ b/UniversalBootstrapDemo/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.5
+// swift-tools-version:5.6
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/backpressure-file-io-channel/Package.swift
+++ b/backpressure-file-io-channel/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.5
+// swift-tools-version:5.6
 import PackageDescription
 
 let package = Package(

--- a/connect-proxy/Package.swift
+++ b/connect-proxy/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.5
+// swift-tools-version:5.6
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the SwiftNIO open source project

--- a/http2-client/Package.swift
+++ b/http2-client/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.5
+// swift-tools-version:5.6
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/http2-server/Package.swift
+++ b/http2-server/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.5
+// swift-tools-version:5.6
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the SwiftNIO open source project

--- a/json-rpc/Package.swift
+++ b/json-rpc/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.5
+// swift-tools-version:5.6
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/json-rpc/Tests/JsonRpcTests/JsonRpcTests.swift
+++ b/json-rpc/Tests/JsonRpcTests/JsonRpcTests.swift
@@ -283,7 +283,7 @@ final class JSONRPCTests: XCTestCase {
         }
         // perform another method call
         XCTAssertThrowsError(try client.call(method: "disconnect", params: .none).wait()) { error in
-            XCTAssertEqual(error as! NIO.ChannelError, NIO.ChannelError.ioOnClosedChannel)
+            XCTAssertEqual(error as! NIOCore.ChannelError, NIOCore.ChannelError.ioOnClosedChannel)
         }
         // shutdown
         try! client.disconnect().wait()
@@ -424,7 +424,7 @@ final class JSONRPCTests: XCTestCase {
         let request = JSONRequest(id: UUID().uuidString, method: "foo", params: .none)
         let json = try! JSONEncoder().encode(request)
         XCTAssertThrowsError(try client.request(string: String(data: json, encoding: .utf8)!).wait()) { error in
-            XCTAssertEqual(error as! NIO.ChannelError, NIO.ChannelError.ioOnClosedChannel)
+            XCTAssertEqual(error as! NIOCore.ChannelError, NIOCore.ChannelError.ioOnClosedChannel)
         }
         // shutdown
         try! client.disconnect().wait()

--- a/nio-launchd/Package.swift
+++ b/nio-launchd/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.5
+// swift-tools-version:5.6
 import PackageDescription
 
 let package = Package(


### PR DESCRIPTION
As the rest of the NIO project is about to drop 5.5 support, we should stop supporting it in the examples too.
