### PR TITLE
Move connection setup to channelActive unless it already is.

### DIFF
--- a/TLSify/Sources/TLSifyLib/TLSProxy.swift
+++ b/TLSify/Sources/TLSifyLib/TLSProxy.swift
@@ -138,8 +138,11 @@ extension TLSProxy: ChannelDuplexHandler {
     public func handlerAdded(context: ChannelHandlerContext) {
         self.logger[metadataKey: "channel"] = "\(context.channel)"
 
-        self.logger.trace("added to Channel", metadata: ["isActive": "\(context.channel.isActive)"])
-        self.beginConnecting(context: context)
+        let isActive = context.channel.isActive
+        self.logger.trace("added to Channel", metadata: ["isActive": "\(isActive)"])
+        if isActive {
+            self.beginConnecting(context: context)
+        }
     }
 
     public func channelActive(context: ChannelHandlerContext) {

--- a/TLSify/Sources/TLSifyLib/TLSProxy.swift
+++ b/TLSify/Sources/TLSifyLib/TLSProxy.swift
@@ -19,13 +19,13 @@ import Logging
 
 public final class TLSProxy {
     enum State {
-        case waitingToBeAdded
+        case waitingToBeActivated
         case connecting(ByteBuffer)
         case connected
         case error(Error)
         case closed
     }
-    private var state = State.waitingToBeAdded {
+    private var state = State.waitingToBeActivated {
         didSet {
             self.logger.trace("SM new state: \(self.state)")
         }
@@ -53,7 +53,7 @@ public final class TLSProxy {
         self.logger.warning("unexpected error: \(#function): \(error)")
 
         switch self.state {
-        case .connected, .connecting, .waitingToBeAdded, .closed:
+        case .connected, .connecting, .waitingToBeActivated, .closed:
             self.state = .error(error)
         case .error:
             ()
@@ -67,7 +67,7 @@ public final class TLSProxy {
 
         let bytes: ByteBuffer
         switch self.state {
-        case .waitingToBeAdded, .connected:
+        case .waitingToBeActivated, .connected:
             self.illegalTransition()
         case .error(let error):
             partnerChannel.pipeline.fireErrorCaught(error)
@@ -138,9 +138,18 @@ extension TLSProxy: ChannelDuplexHandler {
     public func handlerAdded(context: ChannelHandlerContext) {
         self.logger[metadataKey: "channel"] = "\(context.channel)"
 
-        self.logger.trace("added to Channel")
+        self.logger.trace("added to Channel", metadata: ["isActive": "\(context.channel.isActive)"])
+        self.beginConnecting(context: context)
+    }
+
+    public func channelActive(context: ChannelHandlerContext) {
+        self.logger.trace("Received channelActive")
+        self.beginConnecting(context: context)
+    }
+
+    private func beginConnecting(context: ChannelHandlerContext) {
         switch self.state {
-        case .waitingToBeAdded:
+        case .waitingToBeActivated:
             self.state = .connecting(context.channel.allocator.buffer(capacity: 0))
             self.connectPartner(eventLoop: context.eventLoop).whenComplete { result in
                 switch result {
@@ -154,9 +163,9 @@ extension TLSProxy: ChannelDuplexHandler {
                                    contextForInitialData: context)
                 }
             }
-        case .connected, .connecting:
-            self.illegalTransition()
-        case .error, .closed:
+        case .connecting, .connected, .error, .closed:
+            // Duplicate call, fine. Can happen if channelActive is awkwardly
+            // ordered.
             ()
         }
     }
@@ -175,7 +184,7 @@ extension TLSProxy: ChannelDuplexHandler {
             }
         case .error, .closed:
             () // we can drop this
-        case .waitingToBeAdded:
+        case .waitingToBeActivated:
             self.illegalTransition()
         }
     }
@@ -186,7 +195,7 @@ extension TLSProxy: ChannelDuplexHandler {
             context.read()
         case .connecting, .error, .closed:
             () // No, let's not read more that we'd need to buffer/drop anyway
-        case .waitingToBeAdded:
+        case .waitingToBeActivated:
             self.illegalTransition()
         }
     }
@@ -201,7 +210,7 @@ extension TLSProxy: ChannelDuplexHandler {
             self.state = .closed
         case .error:
             ()
-        case .closed, .waitingToBeAdded:
+        case .closed, .waitingToBeActivated:
             self.illegalTransition()
         }
     }


### PR DESCRIPTION
Motivation

Generally handlerAdded is a bit too early to go making outbound connections. Better to wait for channelActive, which prevents the Channels needing to queue data if the outbound connection happens quickly.

Modifications

Unify the connection flow
Call into it from channelActive _or_ handlerAdded on activation

Result

More reliable code.
