### PR TITLE
TLSify: close on error

### DIFF
--- a/TLSify/Sources/TLSify/main.swift
+++ b/TLSify/Sources/TLSify/main.swift
@@ -58,10 +58,13 @@ struct TLSifyCommand: ParsableCommand {
             ServerBootstrap(group: el)
                 .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
                 .childChannelInitializer { channel in
-                    channel.pipeline.addHandler(TLSProxy(host: self.connectHost,
-                                                         port: self.connectPort,
-                                                         sslContext: sslContext,
-                                                         logger: rootLogger))
+                    channel.pipeline.addHandlers([
+                        TLSProxy(host: self.connectHost,
+                                 port: self.connectPort,
+                                 sslContext: sslContext,
+                                 logger: rootLogger),
+                        CloseOnErrorHandler(logger: rootLogger),
+                    ])
                 }
                 .bind(host: self.listenHost, port: self.listenPort)
             .map { channel in

--- a/TLSify/Sources/TLSifyLib/CloseOnErrorHandler.swift
+++ b/TLSify/Sources/TLSifyLib/CloseOnErrorHandler.swift
@@ -15,16 +15,16 @@
 import NIOCore
 import Logging
 
-final class CloseOnErrorHandler: ChannelInboundHandler, Sendable {
-    typealias InboundIn = Never
+public final class CloseOnErrorHandler: ChannelInboundHandler, Sendable {
+    public typealias InboundIn = Never
 
     private let logger: Logger
 
-    init(logger: Logger) {
+    public init(logger: Logger) {
         self.logger = logger
     }
 
-    func errorCaught(context: ChannelHandlerContext, error: Error) {
+    public func errorCaught(context: ChannelHandlerContext, error: Error) {
         self.logger.info("unhandled error \(error), closing \(context.channel)")
         context.close(promise: nil)
     }


### PR DESCRIPTION
### Motivation:

The `TLSProxy` handler expected that it can just forward errors to abandon the incoming connection. Unfortunately, the `CloseOnErrorHandler` was never added.

### Modifications:

- Add the `CloseOnErrorHandler` as `TLSProxy` expected.

### Result:

- No longer just goes silent on connections that had an error.
- For example: When connecting to an upstream where the connect fails, we'd previously just ghost the downstream connection leaving the other peer hanging until it gives up.