### PR TITLE
remove "http/1.1" from accepted protocols in server example

### DIFF
--- a/http2-server/Sources/http2-server/main.swift
+++ b/http2-server/Sources/http2-server/main.swift
@@ -113,7 +113,7 @@ let sslCertificate = try! NIOSSLCertificateSource.certificate(NIOSSLCertificate(
 // `NIOHTTP2SupportedALPNProtocols` which (using ALPN (https://en.wikipedia.org/wiki/Application-Layer_Protocol_Negotiation))
 // advertises the support of HTTP/2 to the client.
 var serverConfig = TLSConfiguration.makeServerConfiguration(certificateChain: [sslCertificate], privateKey: sslPrivateKey)
-serverConfig.applicationProtocols = NIOHTTP2SupportedALPNProtocols
+serverConfig.applicationProtocols = ["h2"]
 // Configure the SSL context that is used by all SSL handlers.
 let sslContext = try! NIOSSLContext(configuration: serverConfig)
 


### PR DESCRIPTION
passing `NIOHTTP2SupportedALPNProtocols` here is wrong, if the client offers HTTP/1.1 (e.g. `curl --http1.1 -v https://localhost/`), the server will accept it but fail to respond because the example only supports HTTP/2.