### PR TITLE
Introduced changes to make projects work with require-explicit-sendable

### DIFF
--- a/UniversalBootstrapDemo/Package.swift
+++ b/UniversalBootstrapDemo/Package.swift
@@ -39,7 +39,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.81.0"),
         .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.16.1"),
         .package(url: "https://github.com/apple/swift-nio-transport-services.git", from: "1.11.3"),
-        .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.5.0")
+        .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.5.0"),
     ],
     targets: [
         .executableTarget(
@@ -53,6 +53,6 @@ let package = Package(
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
             ],
             swiftSettings: strictConcurrencySettings
-        ),
+        )
     ]
 )

--- a/UniversalBootstrapDemo/Sources/UniversalBootstrapDemo/EventLoopGroupManager.swift
+++ b/UniversalBootstrapDemo/Sources/UniversalBootstrapDemo/EventLoopGroupManager.swift
@@ -39,7 +39,7 @@ public class EventLoopGroupManager: @unchecked Sendable {
     private let provider: Provider
     private var sslContext = try! NIOSSLContext(configuration: .makeClientConfiguration())
 
-    public enum Provider {
+    public enum Provider: Sendable {
         case createNew
         case shared(EventLoopGroup)
     }

--- a/backpressure-file-io-channel/Package.swift
+++ b/backpressure-file-io-channel/Package.swift
@@ -36,7 +36,7 @@ let strictConcurrencySettings: [SwiftSetting] = {
 let package = Package(
     name: "backpressure-file-io-channel",
     platforms: [
-        .macOS(.v10_15), .iOS(.v13), .tvOS(.v13)
+        .macOS(.v10_15), .iOS(.v13), .tvOS(.v13),
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.81.0"),
@@ -50,7 +50,8 @@ let package = Package(
                 .product(name: "NIOPosix", package: "swift-nio"),
                 .product(name: "NIOHTTP1", package: "swift-nio"),
                 .product(name: "Logging", package: "swift-log"),
-            ]),
+            ]
+        ),
         .executableTarget(
             name: "BackpressureChannelToFileIODemo",
             dependencies: [

--- a/backpressure-file-io-channel/Sources/BackpressureChannelToFileIO/SaveEverythingHTTPServer.swift
+++ b/backpressure-file-io-channel/Sources/BackpressureChannelToFileIO/SaveEverythingHTTPServer.swift
@@ -45,7 +45,7 @@ public final class SaveEverythingHTTPServer {
 }
 
 @available(*, unavailable)
-extension SaveEverythingHTTPServer: Sendable { }
+extension SaveEverythingHTTPServer: Sendable {}
 
 // MARK: - The handler for the Actions the state machine recommends to do
 extension SaveEverythingHTTPServer {

--- a/backpressure-file-io-channel/Sources/BackpressureChannelToFileIO/SaveEverythingHTTPServer.swift
+++ b/backpressure-file-io-channel/Sources/BackpressureChannelToFileIO/SaveEverythingHTTPServer.swift
@@ -16,7 +16,6 @@ import Logging
 import NIOCore
 import NIOHTTP1
 import NIOPosix
-import _NIOFileSystem
 
 public final class SaveEverythingHTTPServer {
     private var state = FileIOCoordinatorState() {

--- a/backpressure-file-io-channel/Sources/BackpressureChannelToFileIO/SaveEverythingHTTPServer.swift
+++ b/backpressure-file-io-channel/Sources/BackpressureChannelToFileIO/SaveEverythingHTTPServer.swift
@@ -16,6 +16,7 @@ import Logging
 import NIOCore
 import NIOHTTP1
 import NIOPosix
+import _NIOFileSystem
 
 public final class SaveEverythingHTTPServer {
     private var state = FileIOCoordinatorState() {

--- a/backpressure-file-io-channel/Sources/BackpressureChannelToFileIO/SaveEverythingHTTPServer.swift
+++ b/backpressure-file-io-channel/Sources/BackpressureChannelToFileIO/SaveEverythingHTTPServer.swift
@@ -44,6 +44,9 @@ public final class SaveEverythingHTTPServer {
 
 }
 
+@available(*, unavailable)
+extension SaveEverythingHTTPServer: Sendable { }
+
 // MARK: - The handler for the Actions the state machine recommends to do
 extension SaveEverythingHTTPServer {
     func runAction(_ action: FileIOCoordinatorState.Action, context: ChannelHandlerContext) {

--- a/connect-proxy/Package.swift
+++ b/connect-proxy/Package.swift
@@ -36,7 +36,7 @@ let strictConcurrencySettings: [SwiftSetting] = {
 let package = Package(
     name: "nio-connect-proxy",
     products: [
-        .executable(name: "ConnectProxy", targets: ["ConnectProxy"]),
+        .executable(name: "ConnectProxy", targets: ["ConnectProxy"])
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.81.0"),
@@ -51,7 +51,7 @@ let package = Package(
                 .product(name: "NIOHTTP1", package: "swift-nio"),
                 .product(name: "Logging", package: "swift-log"),
             ],
-        swiftSettings: strictConcurrencySettings
-        ),
+            swiftSettings: strictConcurrencySettings
+        )
     ]
 )

--- a/http2-client/Package.swift
+++ b/http2-client/Package.swift
@@ -57,6 +57,6 @@ let package = Package(
                 .product(name: "NIOExtras", package: "swift-nio-extras"),
             ],
             swiftSettings: strictConcurrencySettings
-        ),
+        )
     ]
 )

--- a/http2-client/Sources/http2-client/Types.swift
+++ b/http2-client/Sources/http2-client/Types.swift
@@ -68,7 +68,7 @@ public struct HTTPRequest {
 }
 
 @available(*, unavailable)
-extension HTTPRequest: Sendable { }
+extension HTTPRequest: Sendable {}
 
 extension HTTPRequest._Storage {
     func copy() -> HTTPRequest._Storage {

--- a/http2-client/Sources/http2-client/Types.swift
+++ b/http2-client/Sources/http2-client/Types.swift
@@ -20,7 +20,7 @@ struct HostAndPort: Equatable, Hashable {
 }
 
 public struct HTTPRequest {
-    class _Storage {
+    final class _Storage {
         var method: HTTPMethod
         var target: String
         var version: HTTPVersion
@@ -66,6 +66,9 @@ public struct HTTPRequest {
         )
     }
 }
+
+@available(*, unavailable)
+extension HTTPRequest: Sendable { }
 
 extension HTTPRequest._Storage {
     func copy() -> HTTPRequest._Storage {

--- a/http2-server/Package.swift
+++ b/http2-server/Package.swift
@@ -53,6 +53,6 @@ let package = Package(
                 .product(name: "NIOHTTP2", package: "swift-nio-http2"),
             ],
             swiftSettings: strictConcurrencySettings
-        ),
+        )
     ]
 )

--- a/json-rpc/Sources/JsonRpc/Client.swift
+++ b/json-rpc/Sources/JsonRpc/Client.swift
@@ -127,7 +127,7 @@ public final class TCPClient: @unchecked Sendable {
             )
         }
 
-        public enum Kind {
+        public enum Kind: Sendable {
             case invalidMethod
             case invalidParams
             case invalidRequest
@@ -151,7 +151,7 @@ public final class TCPClient: @unchecked Sendable {
         }
     }
 
-    public struct Config {
+    public struct Config: Sendable {
         public let timeout: TimeAmount
         public let framing: Framing
 

--- a/json-rpc/Sources/JsonRpc/Server.swift
+++ b/json-rpc/Sources/JsonRpc/Server.swift
@@ -91,7 +91,7 @@ public final class TCPServer: @unchecked Sendable {
         case stopped
     }
 
-    public struct Config {
+    public struct Config: Sendable {
         public let timeout: TimeAmount
         public let framing: Framing
 

--- a/json-rpc/Sources/JsonRpc/Utils.swift
+++ b/json-rpc/Sources/JsonRpc/Utils.swift
@@ -19,7 +19,7 @@ public enum ResultType<Value, Error>: Sendable where Value: Sendable, Error: Sen
     case failure(Error)
 }
 
-public enum Framing: CaseIterable {
+public enum Framing: CaseIterable, Sendable {
     case `default`
     case jsonpos
     case brute

--- a/json-rpc/Tests/JsonRpcTests/XCTestManifests.swift
+++ b/json-rpc/Tests/JsonRpcTests/XCTestManifests.swift
@@ -12,7 +12,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-
 #if !canImport(ObjectiveC)
 import XCTest
 
@@ -41,8 +40,8 @@ extension JSONRPCTests {
 }
 
 public func __allTests() -> [XCTestCaseEntry] {
-    return [
-        testCase(JSONRPCTests.__allTests__JSONRPCTests),
+    [
+        testCase(JSONRPCTests.__allTests__JSONRPCTests)
     ]
 }
 #endif

--- a/nio-launchd/Package.swift
+++ b/nio-launchd/Package.swift
@@ -48,6 +48,6 @@ let package = Package(
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
             ],
             swiftSettings: strictConcurrencySettings
-        ),
+        )
     ]
 )


### PR DESCRIPTION
Added Sendable conformances to a few types to ensure projects can be compiled with `-require-explicit-sendable`.