### PR TITLE
update `actions/checkout` from v4 to v6

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
       build-test-matrix: '${{ steps.generate-matrix.outputs.build-test-matrix }}'
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           persist-credentials: false
       - id: generate-matrix
@@ -41,7 +41,7 @@ jobs:
       release-build-test-matrix: '${{ steps.generate-matrix.outputs.build-test-matrix }}'
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           persist-credentials: false
       - id: generate-matrix

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -23,7 +23,7 @@ jobs:
       build-test-matrix: '${{ steps.generate-matrix.outputs.build-test-matrix }}'
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           persist-credentials: false
       - id: generate-matrix
@@ -47,7 +47,7 @@ jobs:
       release-build-test-matrix: '${{ steps.generate-matrix.outputs.build-test-matrix }}'
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           persist-credentials: false
       - id: generate-matrix


### PR DESCRIPTION
Motivation

* Following [GitHub's announcement](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/), Node 20 is being deprecated and runners will begin using Node 24 by default starting March 4th, 2026. Node 20 will reach end-of-life in April 2026.

Modifications

* Upgrade GitHub Actions to their latest versions to ensure compatibility with Node 24.
* Replace `actions/checkout@v4` with `actions/checkout@v6` in all workflow files.

Result

* Workflow files reference `actions/checkout@v6`.
